### PR TITLE
AZ selection and s3 gateway

### DIFF
--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -1,0 +1,294 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation stack for https://github.com/runs-on/runs-on
+
+Metadata: 
+  AWS::CloudFormation::Interface: 
+    ParameterGroups: 
+      - 
+        Label: 
+          default: "GitHub Configuration"
+        Parameters: 
+          - GithubOrganization
+      - 
+        Label: 
+          default: "Cost usage"
+        Parameters: 
+          - EmailAddress
+      - 
+        Label: 
+          default: "App Configuration"
+        Parameters: 
+          - AppImageVersion
+          - AppImageRepository
+          - AppCPU
+          - AppMemory
+      - 
+        Label: 
+          default: "Security Configuration"
+        Parameters: 
+          - SSHCidrRange
+    ParameterLabels:
+      GithubOrganization: 
+        default: "Your GitHub organization or personal name."
+
+Parameters:
+  GithubOrganization:
+    Type: String
+    Description: "For instance if your GitHub organization lives on https://github.com/my-org, then the value of this parameter should be: my-org"
+    MinLength: 1
+
+  EmailAddress:
+    Type: String
+    Description: Email address for usage alerts (optional)
+
+  SSHCidrRange:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: CIDR range for SSH access. By default, only repository collaborators with push permission will be able to SSH into the runner instances.
+
+  AppCPU:
+    Type: Number
+    Default: "256"
+    Description: CPU units for RunsOn service (256 or higher)
+  
+  AppMemory:
+    Type: Number
+    Default: "512"
+    Description: Memory in MB for RunsOn service (512 or higher)
+
+  AppImageRepository:
+    Type: String
+    Default: "public.ecr.aws/c5h5o9k1/runs-on/runs-on"
+    Description: ECR repository where the app image exists
+
+  AppImageVersion:
+    Type: String
+    Default: "v1.3.9"
+    Description: Version of the app in the AppImageRepository
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      CidrBlock: 10.0.0.0/24
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  SubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for SSH access
+      VpcId:
+        Ref: VPC
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::Sub: "${SSHCidrRange}"
+          FromPort: 22
+          ToPort: 22
+          IpProtocol: tcp
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  RunsOnService:
+    Type: AWS::AppRunner::Service
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      InstanceConfiguration:
+        Cpu: !Ref AppCPU
+        Memory: !Ref AppMemory
+        InstanceRoleArn: !GetAtt RunsOnServiceRole.Arn
+      NetworkConfiguration:
+        EgressConfiguration:
+          EgressType: DEFAULT
+        IngressConfiguration:
+          IsPubliclyAccessible: true
+        IpAddressType: IPV4
+      HealthCheckConfiguration:
+        Path: /
+        Protocol: HTTP
+        HealthyThreshold: 1
+        UnhealthyThreshold: 15
+        Interval: 10
+      SourceConfiguration:
+        ImageRepository:
+          ImageConfiguration:
+            Port: 80
+            RuntimeEnvironmentVariables:
+              - Name: RUNS_ON_TOPIC_ARN
+                Value: !Ref AlertTopic
+              - Name: RUNS_ON_S3_BUCKET
+                Value: !Ref S3Bucket
+              - Name: RUNS_ON_STACK_NAME
+                Value: !Ref AWS::StackName
+              - Name: RUNS_ON_SUBNET_ID
+                Value: !Ref PublicSubnet
+              - Name: RUNS_ON_SECURITY_GROUP_ID
+                Value: !Ref SecurityGroup
+              - Name: RUNS_ON_ORG
+                Value: !Ref GithubOrganization
+          ImageIdentifier: !Sub ${AppImageRepository}:${AppImageVersion}
+          ImageRepositoryType: ECR_PUBLIC
+
+  RunsOnServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - tasks.apprunner.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: AppRunnerEC2Permissions
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:Describe*
+                  - ce:GetCostAndUsage
+                  - ce:UpdateCostAllocationTagsStatus
+                  - iam:CreateServiceLinkedRole
+                  - cloudwatch:PutMetricData
+                  - cloudwatch:GetMetricData
+                  - cloudwatch:DescribeAlarms
+                  - sns:ListTopics
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ec2:RunInstances
+                Resource:
+                  - arn:aws:ec2:*:*:network-interface/*
+                  - arn:aws:ec2:*:*:volume/*
+                  - arn:aws:ec2:*:*:security-group/*
+                  - arn:aws:ec2:*::image/ami-*
+                  - Fn::Sub: arn:aws:ec2:*:*:subnet/${PublicSubnet}
+              - Effect: Allow
+                Action:
+                  - ec2:CreateTags
+                  - ec2:RunInstances
+                Resource: arn:aws:ec2:*:*:instance/*
+              - Effect: Allow
+                Action:
+                  - ec2:TerminateInstances
+                Resource: "arn:aws:ec2:*:*:instance/*"
+                Condition:
+                  StringEquals:
+                    "aws:ResourceTag/stack": !Ref AWS::StackName
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource: 
+                  - Fn::Sub: arn:aws:s3:::${S3Bucket}
+                  - Fn::Sub: arn:aws:s3:::${S3Bucket}/*
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref AlertTopic
+
+  MinutesPerDayAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alerts when the daily usage of the RunsOn service exceeds 6000 minutes
+      Namespace: RunsOn 
+      MetricName: minutes
+      Statistic: Sum   # Choose the appropriate statistic (e.g., Sum, Average, Maximum)
+      Period: 86400   # Set to 24 hours for 1-day periods (adjust as needed)
+      EvaluationPeriods: 1
+      Threshold: 40
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref AlertTopic
+      OKActions:
+        - !Ref AlertTopic
+
+  AlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      DisplayName: RunsOn Alerts
+
+  AlertTopicSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: email
+      TopicArn: !Ref AlertTopic
+      Endpoint: !If [EmailProvided, !Ref EmailAddress, '']
+
+Conditions:
+  EmailProvided: !Not [!Equals [!Ref EmailAddress, '']]
+
+Outputs:
+  RunsOnEntryPoint:
+    Description: Entrypoint for the RunsOn service
+    Value: !GetAtt RunsOnService.ServiceUrl

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -22,6 +22,11 @@ Metadata:
           - AppImageRepository
           - AppCPU
           - AppMemory
+      -
+        Label:
+          default: "Network Configuration"
+        Parameters:
+          - AvailabilityZone
       - 
         Label: 
           default: "Security Configuration"
@@ -40,6 +45,10 @@ Parameters:
   EmailAddress:
     Type: String
     Description: Email address for usage alerts (optional)
+
+  AvailabilityZone:
+    Type: AWS::EC2::AvailabilityZone::Name
+    Description: "The availability zone where the stack will be created. You can update this at any time, for instance if you find out that some AZ does not have the latest instance types."
 
   SSHCidrRange:
     Type: String
@@ -66,6 +75,41 @@ Parameters:
     Default: "v1.3.9"
     Description: Version of the app in the AppImageRepository
 
+
+Transform: 'AWS::LanguageExtensions'
+
+Mappings:
+  Networking:
+    AzSuffixToIndex:
+      1a: 0
+      1b: 1
+      1c: 2
+      1d: 3
+      1e: 4
+      1f: 5
+      1g: 6
+      2a: 0
+      2b: 1
+      2c: 2
+      2d: 3
+      2e: 4
+      2f: 5
+      2g: 6
+      3a: 0
+      3b: 1
+      3c: 2
+      3d: 3
+      3e: 4
+      3f: 5
+      3g: 6
+      4a: 0
+      4b: 1
+      4c: 2
+      4d: 3
+      4e: 4
+      4f: 5
+      4g: 6
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -82,12 +126,28 @@ Resources:
     Properties:
       VpcId:
         Ref: VPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
-      CidrBlock: 10.0.0.0/24
+      AvailabilityZone:
+        Ref: AvailabilityZone
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [
+        !FindInMap [Networking, AzSuffixToIndex, !Select [ 2, !Split [ "-", !Ref AvailabilityZone]]],
+        !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]
+      ]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+
+  S3VpcEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref VPC
+      ServiceName:
+        Fn::Sub: "com.amazonaws.${AWS::Region}.s3"
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PublicRouteTable
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -72,7 +72,7 @@ Parameters:
 
   AppImageVersion:
     Type: String
-    Default: "v1.3.9"
+    Default: "v1.3.10"
     Description: Version of the app in the AppImageRepository
 
 

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -240,6 +240,8 @@ Resources:
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_STACK_NAME
                 Value: !Ref AWS::StackName
+              - Name: RUNS_ON_AVAILABILITY_ZONE
+                Value: !Ref AvailabilityZone
               - Name: RUNS_ON_SUBNET_ID
                 Value: !Ref PublicSubnet
               - Name: RUNS_ON_SECURITY_GROUP_ID

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -22,6 +22,11 @@ Metadata:
           - AppImageRepository
           - AppCPU
           - AppMemory
+      -
+        Label:
+          default: "Network Configuration"
+        Parameters:
+          - AvailabilityZone
       - 
         Label: 
           default: "Security Configuration"
@@ -40,6 +45,10 @@ Parameters:
   EmailAddress:
     Type: String
     Description: Email address for usage alerts (optional)
+
+  AvailabilityZone:
+    Type: AWS::EC2::AvailabilityZone::Name
+    Description: "The availability zone where the stack will be created. You can update this at any time, for instance if you find out that some AZ does not have the latest instance types."
 
   SSHCidrRange:
     Type: String
@@ -63,8 +72,43 @@ Parameters:
 
   AppImageVersion:
     Type: String
-    Default: "v1.3.10"
+    Default: "v1.3.9"
     Description: Version of the app in the AppImageRepository
+
+
+Transform: 'AWS::LanguageExtensions'
+
+Mappings:
+  Networking:
+    AzSuffixToIndex:
+      1a: 0
+      1b: 1
+      1c: 2
+      1d: 3
+      1e: 4
+      1f: 5
+      1g: 6
+      2a: 0
+      2b: 1
+      2c: 2
+      2d: 3
+      2e: 4
+      2f: 5
+      2g: 6
+      3a: 0
+      3b: 1
+      3c: 2
+      3d: 3
+      3e: 4
+      3f: 5
+      3g: 6
+      4a: 0
+      4b: 1
+      4c: 2
+      4d: 3
+      4e: 4
+      4f: 5
+      4g: 6
 
 Resources:
   VPC:
@@ -82,12 +126,28 @@ Resources:
     Properties:
       VpcId:
         Ref: VPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
-      CidrBlock: 10.0.0.0/24
+      AvailabilityZone:
+        Ref: AvailabilityZone
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [
+        !FindInMap [Networking, AzSuffixToIndex, !Select [ 2, !Split [ "-", !Ref AvailabilityZone]]],
+        !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]
+      ]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+
+  S3VpcEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref VPC
+      ServiceName:
+        Fn::Sub: "com.amazonaws.${AWS::Region}.s3"
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PublicRouteTable
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -72,7 +72,7 @@ Parameters:
 
   AppImageVersion:
     Type: String
-    Default: "v1.3.9"
+    Default: "v1.3.10"
     Description: Version of the app in the AppImageRepository
 
 

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -240,6 +240,8 @@ Resources:
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_STACK_NAME
                 Value: !Ref AWS::StackName
+              - Name: RUNS_ON_AVAILABILITY_ZONE
+                Value: !Ref AvailabilityZone
               - Name: RUNS_ON_SUBNET_ID
                 Value: !Ref PublicSubnet
               - Name: RUNS_ON_SECURITY_GROUP_ID


### PR DESCRIPTION
- Allow AZ selection to alleviate #5 
- Adds an S3 gateway endpoint for the VPC so that any S3 traffic from runners stay private
- Increase subnet size to allow for 4k+ runners at the same time

Some companies have workflows that currently launch 100s of runners at once due to the official GitHub runners having limited vCPU count (hence aggressively sharding their test suite), and I want the transition to be as smooth as possible.

The AZ change is so that one can switch to a better AZ for better pricing / better instance type availability instead of defaulting to the first AZ of every region.