### PR TITLE
Delay allocation tag registration for 24h after install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ push:
 s3-upload:
 	aws s3 cp --recursive ./cloudformation s3://runs-on/cloudformation
 
+s3-upload-dev:
+	aws s3 cp ./cloudformation/template-dev.yaml s3://runs-on/cloudformation/
+
 release: bump login build push s3-upload
 	docker tag public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(VERSION) public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(MAJOR_VERSION)
 	docker push public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(MAJOR_VERSION)

--- a/app.js
+++ b/app.js
@@ -36,8 +36,9 @@ module.exports = async (app) => {
     awsCredentials: defaultProvider({
       roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
       roleAssumer: getDefaultRoleAssumer(),
-    })
+    }),
   }
+  app.state.devMode = process.env["RUNS_ON_ENV"] === "dev"
 
   // delay first initialization to bind socket asap
   setTimeout(async () => {

--- a/data/email_costs_template.md.hbs
+++ b/data/email_costs_template.md.hbs
@@ -2,8 +2,8 @@ Hello, please find below the daily costs for the `{{stackTagKey}}:{{stackTagName
 
 ## Daily costs
 
-| Date       | Cost       |
-|------------|------------|
+| Date       | Cost |
+|------------|------|
 {{#costs}}
 | {{TimePeriod.End}} | {{round Total.BlendedCost.Amount}} |
 {{/costs}}


### PR DESCRIPTION
This will give time for the new tag to make its way into AWS database.