### PR TITLE
Fix instance selection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -27,11 +27,11 @@ const DEFAULT_HDD = 100;
 const DEFAULT_IOPS = 0;
 const DEFAULT_THROUGHPUT = 400;
 const DEFAULT_FAMILY_FOR_PLATFORM = {
-  PLATFORM_LINUX: "c*",
-  PLATFORM_MACOS: "mac*",
-  PLATFORM_WINDOWS: "c*",
+  [PLATFORM_LINUX]: "c7*",
+  [PLATFORM_MACOS]: "mac*",
+  [PLATFORM_WINDOWS]: "c7*",
 }
-const DEFAULT_PLATFORM = "Linux/UNIX";
+const DEFAULT_PLATFORM = PLATFORM_LINUX;
 const DEFAULT_USER = "ubuntu";
 
 // AWS architecture mappings
@@ -45,11 +45,11 @@ const SUPPORTED_ARCHITECTURES = {
 
 // Mapping from runs-on support name to AWS platform name
 const SUPPORTED_PLATFORMS = {
-  PLATFORM_LINUX: PLATFORM_LINUX,
+  [PLATFORM_LINUX]: PLATFORM_LINUX,
   "linux": PLATFORM_LINUX,      // shortname
-  PLATFORM_MACOS: PLATFORM_MACOS,
+  [PLATFORM_MACOS]: PLATFORM_MACOS,
   "macos": PLATFORM_MACOS,      // shortname
-  PLATFORM_WINDOWS: PLATFORM_WINDOWS,
+  [PLATFORM_WINDOWS]: PLATFORM_WINDOWS,
   "windows": PLATFORM_WINDOWS,  // shortname
 }
 

--- a/src/ec2.js
+++ b/src/ec2.js
@@ -145,7 +145,7 @@ function flatMapInput(input) {
 }
 
 const _findInstanceTypesMatching = async function (inputs) {
-  const { arch = DEFAULT_ARCHITECTURE, platform = DEFAULT_PLATFORM, cpu, ram, family } = inputs;
+  const { arch = DEFAULT_ARCHITECTURE, platform = DEFAULT_PLATFORM, cpu = DEFAULT_CPU, ram, family } = inputs;
 
   const familyValues = flatMapInput(family);
   const cpuValues = flatMapInput(cpu).map(i => Number(i));
@@ -232,10 +232,8 @@ const _findInstanceTypesMatching = async function (inputs) {
     // find matching instances for each family, from matchingInstanceTypesByFamily
     // a family can have a wildcard in its name
     const familyRegex = new RegExp(`^${family.replace("*", ".*")}$`);
-    console.log("familyRegex", family, familyRegex)
     // find groups of instance types that match the family
     Object.entries(matchingInstanceTypesByFamily).filter(([familyName]) => {
-      console.log("familyName", familyName)
       return familyName.match(familyRegex)
     }).forEach(([_, instanceTypes]) => {
       instanceTypes.forEach((instanceType) => {
@@ -272,7 +270,7 @@ const createEC2Instance = async function ({
   userDataConfig
 }) {
   const { subnetId, securityGroupId } = app.state.custom;
-  const { cpu = DEFAULT_CPU, ram, iops = DEFAULT_IOPS, hdd = DEFAULT_HDD, family = "c" } = runnerSpec;
+  const { cpu, ram, iops = DEFAULT_IOPS, hdd = DEFAULT_HDD, family } = runnerSpec;
   // https://aws.amazon.com/ebs/pricing/?nc1=h_ls
   const storageType = iops && parseInt(iops) > 0 ? "io2" : "gp3";
 


### PR DESCRIPTION
Properly order instances according to `family` selection.

From support:

> Of the ~20 jobs I've looked at, all spawned with c7a+c7i+m7a+m7i+m7i-flex+c6a+c6i+m6a+m6i get m6idn.4xlarge and all with c7a+c7i+m7a+m7i+m7i-flex get c7i.4xlarge. So I suspect something's up?