### PR TITLE
Faster boot for full ubuntu22 image, better volume sizing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,12 @@ check:
 	if ! git diff --exit-code :^Makefile &>/dev/null ; then echo "You have pending changes. Commit them first" ; exit 1 ; fi
 
 bump: check
-	sed -i 's|Default: "v1.*|Default: "$(VERSION)"|' cloudformation/template.yaml
+	sed -i 's|runs-on:v.*|runs-on:$(VERSION)|' cloudformation/template.yaml
+	cp cloudformation/template.yaml cloudformation/template-$(VERSION).yaml
 	sed -i 's|"version": "v1.*|"version": "$(VERSION)",|' package.json
-	if ! git diff --exit-code cloudformation/template.yaml ; then git commit -m "Bump template to $(VERSION)" Makefile package.json cloudformation/template.yaml && git tag -m "$(VERSION)" "$(VERSION)" ; fi
+
+commit:
+	if ! git diff --exit-code cloudformation/template.yaml ; then git commit -m "Bump template to $(VERSION)" Makefile package.json cloudformation/template.yaml cloudformation/template-$(VERSION).yaml && git tag -m "$(VERSION)" "$(VERSION)" ; fi
 
 login:
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/c5h5o9k1
@@ -23,8 +26,9 @@ push:
 
 s3-upload:
 	aws s3 cp ./cloudformation/template.yaml s3://runs-on/cloudformation/
+	aws s3 cp ./cloudformation/template-v*.yaml s3://runs-on/cloudformation/
 
-release: bump login build push s3-upload
+release: bump commit login build push s3-upload
 	docker tag public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(VERSION) public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(MAJOR_VERSION)
 	docker push public.ecr.aws/c5h5o9k1/runs-on/runs-on:$(MAJOR_VERSION)
 

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ RunsOn comes with preconfigured runner types, which you can select with the `run
 
 Default if no `runner` label provided: `2cpu-linux`.
 
-| runner | cpu | family | $/min (spot) | $/min (on-demand) | $/min (github) | GitHub vs RunsOn |
+| runner | cpu | family | $/min (spot) | $/min (on-demand) | $/min (github) | RunsOn vs GitHub |
 | --- | --- | --- | --- | --- | --- | --- |
-| `1cpu-linux` | 1 | m7a, c7a | 0.0008 | 0.0014 |  |
-| `2cpu-linux` | 2 | m7a, c7a | 0.0011 | 0.0023 | 0.008 | 7x more expensive |
-| `4cpu-linux` | 4 | m7a, c7a | 0.0022 | 0.0043 | 0.016 | 7x more expensive |
-| `8cpu-linux` | 8 | c7a, m7a | 0.0035 | 0.0072 | 0.032 | 9x more expensive |
-| `16cpu-linux` | 16 | c7a, m7a | 0.0068 | 0.0141 | 0.064 | 9x more expensive |
-| `32cpu-linux` | 32 | c7a, m7a | 0.0132 | 0.0278 | 0.128 | 10x more expensive |
-| `48cpu-linux` | 48 | c7a, m7a | 0.0170 | 0.0415 |  |
-| `64cpu-linux` | 64 | c7a, m7a | 0.0196 | 0.0551 |  |
+| `1cpu-linux` | 1 | m7a, m7g | 0.0006 | 0.0012 |  | - |
+| `2cpu-linux` | 2 | m7a, m7g | 0.0010 | 0.0022 | 0.008 | 8x cheaper |
+| `4cpu-linux` | 4 | m7a, m7g, c7a, c7g | 0.0021 | 0.0041 | 0.016 | 8x cheaper |
+| `8cpu-linux` | 8 | c7a, c7g, m7a, m7g | 0.0039 | 0.0076 | 0.032 | 8x cheaper |
+| `16cpu-linux` | 16 | c7a, c7g, m7a, m7g | 0.0072 | 0.0145 | 0.064 | 9x cheaper |
+| `32cpu-linux` | 32 | c7a, c7g, m7a, m7g | 0.0134 | 0.0281 | 0.128 | 10x cheaper |
+| `48cpu-linux` | 48 | c7a, c7g, m7a, m7g | 0.0176 | 0.0421 |  | - |
+| `64cpu-linux` | 64 | c7a, c7g, m7a, m7g | 0.0215 | 0.0557 | 0.256 | 12x cheaper |
 
 You can also define your own custom runner types using the `.github/runs-on.yml` config file:
 
@@ -164,19 +164,17 @@ runs-on: runs-on,runner=gofast
 
 Default if no `image` label provided: `ubuntu22-full-x64`.
 
-| image | platform | arc | owner | user | name |
-| --- | --- | --- | --- | --- | --- |
-| `ubuntu22-full-x64` | linux | x64 | 135269210855 | ubuntu | runner-ubuntu22-* |
-| `ubuntu22-docker-x64` | linux | x64 | 099720109477 | ubuntu | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-* |
-| `ubuntu22-base-x64` | linux | x64 | 099720109477 | ubuntu | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-* |
-| `ubuntu22-docker-arm64` | linux | arm64 | 099720109477 | ubuntu | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-* |
-| `ubuntu22-base-arm64` | linux | arm64 | 099720109477 | ubuntu | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-* |
+| image | platform | arch | user | name |
+| --- | --- | --- | --- | --- |
+| `ubuntu22-full-x64` | linux | x64 | 135269210855 | runs-on-ubuntu22-full-x64-* |
+| `ubuntu22-docker-x64` | linux | x64 | 099720109477 | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-* |
+| `ubuntu22-base-x64` | linux | x64 | 099720109477 | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-* |
+| `ubuntu22-docker-arm64` | linux | arm64 | 099720109477 | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-* |
+| `ubuntu22-base-arm64` | linux | arm64 | 099720109477 | ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-* |
 
-If you want the exact same runner image as what is provided by GitHub, you must use `ubuntu22-full-x64`. Those are refreshed by [runs-on/runner-images-for-aws](https://github.com/runs-on/runner-images-for-aws) every time a new image version is pushed by [GitHub](http://github.com/actions/runner-images).
+If you want the same runner image as what is provided by GitHub, use `ubuntu22-full-x64`. Those are refreshed by [runs-on/runner-images-for-aws](https://github.com/runs-on/runner-images-for-aws) every time a new image version is pushed by [GitHub](http://github.com/actions/runner-images).
 
-The downside of `ubuntu22-full-x64` is that due to how Amazon EBS volumes work, the larger the volume size (and this one is large due to the number of default software installed), the slower the boot time and initial usage while the blocks are fetched from the underlying S3 storage.
-
-All the other images are variants of the bare ubuntu22 official image as provided by canonical. The only additional thing installed is the runner binary. The `ubuntu` user has full `sudo` access if you want to install more things.
+All the other images are variants of the bare ubuntu22 official image as provided by canonical. The only additional thing installed is the runner binary. The `runner` user has full `sudo` access if you want to install more things.
 
 You can also define your own custom images, by using a special config file (`.github/runs-on.yml`) in your repository:
 
@@ -188,7 +186,6 @@ images:
     arch: "x64"
     owner: "099720109477"
     name: "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*",
-    user: "ubuntu" # main user of the AMI
     preinstall: |
       #!/bin/bash
       curl -fsSL https://get.docker.com | sh
@@ -221,7 +218,8 @@ You can choose to override specific aspects of a runner, using the `cpu`, `ram, 
 + runs-on: runs-on,cpu=32,ram=128,hdd=200,family=c7+m7
 ```
 
-Default launch type is `spot` (i.e. 66% cheaper than on-demand, at the risk of being interrupted). If no instance is available at spot price, then the instance will be launched at on-demand price. You can disable `spot` by using `spot=false` in the labels:
+Default launch type is `spot` (i.e. 66% cheaper than on-demand, at the risk of being interrupted). If no instance is available at spot price, then the instance will be launched at on-demand price.
+If you want to ensure your workflows are never interrupted, or if the instance types you require are in short supply, you can disable `spot` by using `spot=false` in the runner labels:
 
 ```diff
 + runs-on: runs-on,runner=16cpu-linux,image=ubuntu22-base-x64,spot=false
@@ -241,12 +239,12 @@ RunsOn takes cost control seriously, since you will be tempted to use beefy runn
 
 All instances are bootstraped with 2 watchdogs, to ensure they are not left running even if GitHub doesn't send the completion webhooks (this happens).
 
-* instance will automatically terminate after 8 hours, no matter whether a workflow is still running on the machine.
+* instance will automatically terminate after 12 hours, no matter whether a workflow is still running on the machine.
 * instance will automatically terminate after 20 minutes, if a workflow job has not been scheduled on the machine.
 
 ### Cost reports right in your inbox
 
-RunsOn automatically reports daily costs for the RunsOn resources, and send them to email configured at installation time:
+RunsOn automatically reports daily costs for the RunsOn resources. Those are sent to the email configured at installation time:
 
 <img width="600" alt="cost report" src="https://github.com/runs-on/runs-on/assets/6114/5c3cc9d0-bf10-467d-bf74-1f731b8524e6">
 
@@ -258,24 +256,25 @@ That's why RunsOn automatically reports errors by sending them to the configured
 
 <img width="600" alt="troubleshooting" src="https://github.com/runs-on/runs-on/assets/6114/d655d6dc-5b7f-4beb-985d-5cda174dd9e0">
 
-Details about the runner, and how to connect to it via SSH, will also be displayed right in the "Set up job" section of the workflow logs:
+Details about the runner, launch timings, and SSH connection details will also be displayed right in the "Set up job" section of the workflow logs:
 
 ![SSH access and runner details](https://github.com/runs-on/runs-on/assets/6114/326cdcfd-3253-4e00-9e52-ea7bae3b8e71)
+
+If you are unable to launch runners due to the default runners using recent family types (m7a/c7a/m7g/c7g), you can switch your installation to another availability zone right from the Cloudformation template.
+
+Available instance types and pricing history can be checked in the AWS UI, for instance in <https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SpotInstances> for us-east-1.
 
 ## License
 
 The source code for this software is open, but licensed under the [Prosperity Public License 3.0.0](https://prosperitylicense.com). In practice this means that:
 
 * It is indefinitely free to use for non-commercial usage.
+
 * If you install for use in a for-profit organization, you are free to install and evaluate it for 31 days, after which you must buy a license.
 
-> [!IMPORTANT]
-> To celebrate the launch and reward early adopters, a LIFETIME license is available at the special price of 250€ for the first 30 purchases.
-> ➡ [Buy lifetime license](https://buy.runs-on.com).
+License price starts at 300€/year, with best-effort support included. Other license plans are available. For most companies, license cost should be recouped within the first month of usage.
 
-After the first lifetime licenses are gone, the license price for commercial use will be 250€ **per year**, with dedicated support included (for most companies, license cost should be recouped within the first month of usage).
-
-Note: Lifetime license allows indefinite usage of the software and its future versions, but with 1 year of dedicated support only.
+→ [Buy license](https://buy.runs-on.com).
 
 ## Author
 

--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ module.exports = async (app) => {
 
   app.on("workflow_job.queued", async (context) => {
     // https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_job
-    const { repository, workflow_job, deployment } = context.payload;
+    const { repository, workflow_job } = context.payload;
     const { workflow_name, labels } = workflow_job;
     const { repo, owner } = context.repo();
 

--- a/bin/md-specs
+++ b/bin/md-specs
@@ -9,11 +9,11 @@ default_runner=$(node -e 'console.log(require("./src/constants").DEFAULT_RUNNER_
 echo "Default if no \`runner\` label provided: \`$default_runner\`."
 echo ""
 node -e 'console.log(JSON.stringify(require("./src/utils").objToArray(require("./src/constants").RUNNERS)))' | jq -r '
-  ["runner", "cpu", "family", "$/min (spot)", "$/min (on-demand)", "$/min (github)", "GitHub vs RunsOn"],
+  ["runner", "cpu", "family", "$/min (spot)", "$/min (on-demand)", "$/min (github)", "RunsOn vs GitHub"],
   ["---", "---", "---", "---", "---", "---", "---"],
   (.[] | [
     (.key | "`" + . + "`"), .cpu, (.family | join(", ")), .spot_price_per_min, .on_demand_price_per_min,
-    .github_price_per_min, (.github_ratio | select(. != null) | . + "x more expensive")
+    .github_price_per_min, (.github_ratio | (select(. != null) | . + "x cheaper") // "-" )
   ])
   | @tsv | gsub("\t"; " | ") | "| " + . + " |"
 '
@@ -25,8 +25,8 @@ default_image=$(node -e 'console.log(require("./src/constants").DEFAULT_IMAGE_SP
 echo "Default if no \`image\` label provided: \`$default_image\`."
 echo ""
 node -e 'console.log(JSON.stringify(require("./src/utils").objToArray(require("./src/constants").IMAGES)))' | jq -r '
-  ["image", "platform", "arc", "owner", "user", "name"],
-  ["---", "---", "---", "---", "---", "---"],
-  (.[] | [(.key | "`" + . + "`"), .platform, .arch, .owner, .user, .name])
+  ["image", "platform", "arch", "user", "name"],
+  ["---", "---", "---", "---", "---"],
+  (.[] | [(.key | "`" + . + "`"), .platform, .arch, .owner, .name])
   | @tsv | gsub("\t"; " | ") | "| " + . + " |"
 '

--- a/bin/md-specs
+++ b/bin/md-specs
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+node -e 'console.log("onDemandPricing = ", JSON.stringify(require("./src/constants").RUNNERS))'
+
 echo ""
 echo "### Runner types"
 echo ""
@@ -13,7 +15,7 @@ node -e 'console.log(JSON.stringify(require("./src/utils").objToArray(require(".
   ["---", "---", "---", "---", "---", "---", "---"],
   (.[] | [
     (.key | "`" + . + "`"), .cpu, (.family | join(", ")), .spot_price_per_min, .on_demand_price_per_min,
-    .github_price_per_min, (.github_ratio | (select(. != null) | . + "x cheaper") // "-" )
+    .github_price_per_min // "-", (.github_ratio | (select(. != null) | . + "x cheaper") // "-" )
   ])
   | @tsv | gsub("\t"; " | ") | "| " + . + " |"
 '
@@ -30,3 +32,18 @@ node -e 'console.log(JSON.stringify(require("./src/utils").objToArray(require(".
   (.[] | [(.key | "`" + . + "`"), .platform, .arch, .owner, .name])
   | @tsv | gsub("\t"; " | ") | "| " + . + " |"
 '
+
+echo ""
+echo "### Pricing"
+echo ""
+node -e 'console.log(JSON.stringify(require("./src/utils").objToArray(require("./src/constants").RUNNERS)))' | jq -r '
+  ["runner", "cpu", "$/min (RunsOn)", "$/min (GitHub)", "RunsOn vs GitHub"],
+  ["---", "---", "---", "---", "---"],
+  (.[] | [
+    (.key | "`" + . + "`"), .cpu, .spot_price_per_min,
+    .github_price_per_min // "-", (.github_ratio | (select(. != null) | . + "x cheaper") // "-" )
+  ])
+  | @tsv | gsub("\t"; " | ") | "| " + . + " |"
+'
+
+echo ""

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -18,8 +18,6 @@ Metadata:
         Label: 
           default: "App Configuration"
         Parameters: 
-          - AppImageVersion
-          - AppImageRepository
           - AppCPU
           - AppMemory
       -
@@ -64,17 +62,6 @@ Parameters:
     Type: Number
     Default: "512"
     Description: Memory in MB for RunsOn service (512 or higher)
-
-  AppImageRepository:
-    Type: String
-    Default: "public.ecr.aws/c5h5o9k1/runs-on/runs-on"
-    Description: ECR repository where the app image exists
-
-  AppImageVersion:
-    Type: String
-    Default: "v1.4.2"
-    Description: Version of the app in the AppImageRepository
-
 
 Transform: 'AWS::LanguageExtensions'
 
@@ -248,7 +235,7 @@ Resources:
                 Value: !Ref SecurityGroup
               - Name: RUNS_ON_ORG
                 Value: !Ref GithubOrganization
-          ImageIdentifier: !Sub ${AppImageRepository}:${AppImageVersion}
+          ImageIdentifier: public.ecr.aws/c5h5o9k1/runs-on/runs-on:v1.4.2
           ImageRepositoryType: ECR_PUBLIC
 
   RunsOnServiceRole:

--- a/data/user_data/linux.sh.hbs
+++ b/data/user_data/linux.sh.hbs
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 set -o pipefail
-set -x
 
 # Note: this template must be valid for all linux variants (ubuntu, centos, etc), and all supported architectures (x64, arm64, etc)
 
@@ -18,6 +17,38 @@ RUNS_ON_AGENT_WAIT_TIMEOUT=20m
 # https://github.com/actions/actions-runner-controller/blob/master/docs/adrs/2022-10-17-runner-image.md
 RUNS_ON_AGENT_USER="runner"
 RUNS_ON_AGENT_DIR="/home/$RUNS_ON_AGENT_USER"
+RUNS_ON_LAUNCHED_AT={{{ launchedAt }}}
+
+if [ "$(uname -i)" = "aarch64" ]; then
+  echo "Detected arm64 architecture"
+  RUNS_ON_AGENT_ARCH="arm64"
+else
+  echo "Detected x64 architecture"
+  RUNS_ON_AGENT_ARCH="x64"
+fi
+
+# make sure env vars are available to all users
+echo '. /etc/environment' >> /etc/profile
+
+_run_with_timestamp() {
+  "$@"
+  local status=$?
+  local end=$(date -u +"%Y-%m-%dT%H:%M:%S%z")
+  local diff=$(($(date -u -d "$end" +"%s") - $(date -u -d "$RUNS_ON_LAUNCHED_AT" +"%s")))
+  echo "[$end] ${@/_/} (+${diff})" >> /tmp/runs-on-timings.log
+  return $status
+}
+
+_started() {
+  echo "Started"
+}
+
+_ready() {
+  echo "Ready"
+}
+
+echo "[$RUNS_ON_LAUNCHED_AT] launched" >> /tmp/runs-on-timings.log
+_run_with_timestamp _started
 
 _setup_watchdogs() {
   echo "Installing watchdogs..."
@@ -27,17 +58,16 @@ _setup_watchdogs() {
   sleep $RUNS_ON_AGENT_FULL_TIMEOUT && \
     echo "Full timeout reached. Shutting down instance." && _the_end &
 }
+_run_with_timestamp _setup_watchdogs
 
-_setup_watchdogs
-
-# make sure env vars are available to all users
-echo '. /etc/environment' >> /etc/profile
-
-echo "Storing SSH keys..."
-mkdir -p /root/runs-on/
-RUNS_ON_SSH_KEYS_FILE=/root/runs-on/authorized_keys
-# TODO: store those in S3 bucket instead?
-curl -Ls https://github.com/{{ join sshGithubUsernames delimiter=',' wrap='{}' }}.keys > "$RUNS_ON_SSH_KEYS_FILE"
+_store_ssh_keys() {
+  echo "Storing SSH keys..."
+  mkdir -p /root/runs-on/
+  RUNS_ON_SSH_KEYS_FILE=/root/runs-on/authorized_keys
+  # TODO: store those in S3 bucket instead?
+  curl -Ls https://github.com/{{ join sshGithubUsernames delimiter=',' wrap='{}' }}.keys > "$RUNS_ON_SSH_KEYS_FILE"
+}
+_run_with_timestamp _store_ssh_keys
 
 _setup_runner_user() {
   echo "Setting up runner user..."
@@ -46,6 +76,7 @@ _setup_runner_user() {
   echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
   echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 }
+id "$RUNS_ON_AGENT_USER" || _run_with_timestamp _setup_runner_user
 
 _setup_ssh() {
   local homeUser="$RUNS_ON_AGENT_USER"
@@ -57,33 +88,16 @@ _setup_ssh() {
   chown -R "$homeUser":"$homeUser" "$homeDir"/.ssh
   chmod 700 "$homeDir"/.ssh && chmod 600 "$homeDir"/.ssh/authorized_keys
 }
+_run_with_timestamp _setup_ssh || true
 
-id "$RUNS_ON_AGENT_USER" || _setup_runner_user
-_setup_ssh || true
-
-
-EC2_TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-EC2_INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $EC2_TOKEN" -v http://169.254.169.254/latest/meta-data/instance-type)
-EC2_INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $EC2_TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id)
-EC2_INSTANCE_LIFE_CYCLE=$(curl -H "X-aws-ec2-metadata-token: $EC2_TOKEN" -v http://169.254.169.254/latest/meta-data/instance-life-cycle)
-
-echo "Removing useless stuff..."
-rm -rf /etc/cron.d/* /etc/cron.hourly/* /etc/cron.daily/* /etc/cron.monthly/* /etc/cron.weekly/*
-
-echo "Storing preinstall scripts..."
-mkdir -p /root/runs-on/preinstall
-{{#preinstallScripts}}
-echo "{{{.}}}" | base64 -d > /root/runs-on/preinstall/{{@index}}-script.sh
-chmod a+x /root/runs-on/preinstall/{{@index}}-script.sh
-{{/preinstallScripts}}
-
-if [ "$(uname -i)" = "aarch64" ]; then
-  echo "Detected arm64 architecture"
-  RUNS_ON_AGENT_ARCH="arm64"
-else
-  echo "Detected x64 architecture"
-  RUNS_ON_AGENT_ARCH="x64"
-fi
+_fetch_instance_details() {
+  EC2_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+  EC2_INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $EC2_TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
+  EC2_INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $EC2_TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+  EC2_INSTANCE_LIFE_CYCLE=$(curl -s -H "X-aws-ec2-metadata-token: $EC2_TOKEN" http://169.254.169.254/latest/meta-data/instance-life-cycle)
+  echo "Instance type: $EC2_INSTANCE_TYPE\nInstance ID: $EC2_INSTANCE_ID\nInstance lifecycle: $EC2_INSTANCE_LIFE_CYCLE" > /tmp/runs-on-instance-details.log
+}
+_run_with_timestamp _fetch_instance_details || true
 
 cat >> /etc/environment <<EOF
 RUNS_ON_RUNNER_NAME="{{{runnerName}}}"
@@ -99,51 +113,72 @@ set -o allexport
 source /etc/environment
 set +o allexport
 
-_setup_hostname() {
-  echo "Setting up hostname..."
-  hostnamectl set-hostname --pretty "$RUNS_ON_AGENT_USER@$RUNS_ON_RUNNER_IP[$RUNS_ON_RUNNER_NAME]"
-  # echo "127.0.0.1 localhost $runnerName" >> /etc/hosts
+_resize_disk() {
+  if df -hT | grep -q /dev/nvme0n1p1 ; then
+    echo "Detected NVMe disk. Attempting to increase disk size to maximum..."
+    growpart /dev/nvme0n1 1 && resize2fs /dev/nvme0n1p1
+  fi
 }
+_run_with_timestamp _resize_disk || true
 
 _setup_agent() {
-  echo "Installing agent..."
-  mkdir -p "$RUNS_ON_AGENT_DIR"
-  time curl -o "actions-runner-linux.tar.gz" \
-    -L "https://github.com/actions/runner/releases/download/v$RUNS_ON_AGENT_VERSION/actions-runner-linux-$RUNS_ON_AGENT_ARCH-$RUNS_ON_AGENT_VERSION.tar.gz"
-  time tar xzf "./actions-runner-linux.tar.gz" -C $RUNS_ON_AGENT_DIR
+  if ! test -f "$RUNS_ON_AGENT_DIR/run.sh" ; then
+    echo "Agent not found. Installing..."
+    mkdir -p "$RUNS_ON_AGENT_DIR"
+    time curl -o "actions-runner-linux.tar.gz" \
+      -L "https://github.com/actions/runner/releases/download/v$RUNS_ON_AGENT_VERSION/actions-runner-linux-$RUNS_ON_AGENT_ARCH-$RUNS_ON_AGENT_VERSION.tar.gz"
+    time tar xzf "./actions-runner-linux.tar.gz" -C $RUNS_ON_AGENT_DIR
+  else
+    echo "Agent found. Skipping install..."
+  fi
+
   chown -R $RUNS_ON_AGENT_USER:$RUNS_ON_AGENT_USER $RUNS_ON_AGENT_DIR
+  if grep -E '^docker:' /etc/group &>/dev/null ; then
+    echo "Adding $RUNS_ON_AGENT_USER to docker group..."
+    usermod -aG docker $RUNS_ON_AGENT_USER || true
+  fi
 }
+_run_with_timestamp _setup_agent
+
+_setup_preinstall() {
+  echo "Storing preinstall scripts..."
+  mkdir -p /root/runs-on/preinstall
+  {{#preinstallScripts}}
+  echo "{{{.}}}" | base64 -d > /root/runs-on/preinstall/{{@index}}-script.sh
+  chmod a+x /root/runs-on/preinstall/{{@index}}-script.sh
+  {{/preinstallScripts}}
+
+  find /root/runs-on/preinstall -type f -print0 -name "*.sh" | sort --zero-terminated | xargs -r bash
+}
+_run_with_timestamp _setup_preinstall || true
 
 _setup_infos() {
   echo "Storing infos..."
   mkdir -p "$RUNS_ON_AGENT_DIR"
+  local timings=$(cat /tmp/runs-on-timings.log)
+  local instance_details=$(cat /tmp/runs-on-instance-details.log)
+  local ami_details=""
+  if test -s /imagegeneration/imagedata.json ; then
+    ami_details="$(cat /imagegeneration/imagedata.json | sed 's/[][]//g'),"
+  fi
   cat > "$RUNS_ON_AGENT_DIR/.setup_info" <<EOF
 [
+  $ami_details
   {
-    "group": "SSH Access",
-    "detail": "$RUNS_ON_AGENT_USER@$RUNS_ON_RUNNER_IP"
+    "group": "Runner Instance",
+    "detail": "SSH: $RUNS_ON_AGENT_USER@$RUNS_ON_RUNNER_IP\nName: $RUNS_ON_RUNNER_NAME\nArchitecture: $RUNS_ON_AGENT_ARCH\n$instance_details"
   },
   {
-    "group": "Runner",
-    "detail": "Name: $RUNS_ON_RUNNER_NAME\nArchitecture: $RUNS_ON_AGENT_ARCH\nInstance type: $EC2_INSTANCE_TYPE\nInstance ID: $EC2_INSTANCE_ID\nInstance lifecycle: $EC2_INSTANCE_LIFE_CYCLE"
+    "group": "Timings",
+    "detail": "${timings}"
   }
 ]
 EOF
 }
 
-_setup_preinstall() {
-  find /root/runs-on/preinstall -type f -print0 -name "*.sh" | sort --zero-terminated | xargs -r bash
-}
+_run_with_timestamp _ready
 
-_setup_hostname || true
-_setup_agent
-_setup_infos
-_setup_preinstall || true
-
-if grep -E '^docker:' /etc/group &>/dev/null ; then
-  echo "Adding $RUNS_ON_AGENT_USER to docker group..."
-  usermod -aG docker $RUNS_ON_AGENT_USER || true
-fi
+_setup_infos || true
 
 echo "Launching agent..."
 su - $RUNS_ON_AGENT_USER -c "cd $RUNS_ON_AGENT_DIR  && ./run.sh --jitconfig $RUNS_ON_AGENT_JIT_CONFIG"


### PR DESCRIPTION
## Faster boot for large images

`ubuntu22-full-x64`:

* Before: between 140 to 160s from launch to runner ready
* After: between 40 to 60s from launch to runner ready

<img width="469" alt="image" src="https://github.com/runs-on/runs-on/assets/6114/d7a67845-e15a-48e2-9508-0ee8cd613d95">


## Proper disk resizing

Volume is now properly resized, if given `hdd` size is greater than AMI size.

## New timings section in logs

Very useful to compare boot times between runner types / images.

<img width="474" alt="image" src="https://github.com/runs-on/runs-on/assets/6114/badab297-c421-4b5d-8628-c21b0a50b610">

## New license types

* standard
* sponsorship
