### PR TITLE
Workflow monitoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,20 @@ permissions:
 
 jobs:
   test-linux:
-    if: ${{ contains(github.event.head_commit.message, '[dev]') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ contains(github.event.head_commit.message, '[stage]') || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: false
       matrix:
         runner:
-          - runs-on,env=dev
-          - runs-on,cpu=1,env=dev
-          - runs-on,runner=2cpu-linux,iops=800,env=dev
-          - runs-on,runner=gofast,image=custom,env=dev
-          - runs-on,runner=gofast,cpu=1,env=dev
-          - runs-on,cpu=1,env=dev,image=ubuntu22-base-arm64
-          - runs-on,cpu=1,env=dev,image=ubuntu22-full-arm64
+          - runs-on
+          - runs-on,cpu=1
+          - runs-on,runner=2cpu-linux,iops=800
+          - runs-on,runner=gofast,image=custom
+          - runs-on,runner=gofast,cpu=1
+          - runs-on,cpu=1,image=ubuntu22-base-arm64
+          - runs-on,cpu=1,image=ubuntu22-full-arm64
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,8 +30,6 @@ jobs:
       - name: Setup
         run: |
           sudo apt-get update -qq && sudo apt-get install build-essential -y
-          # source RUNS_ON env vars
-          . /etc/environment
           curl https://nodejs.org/dist/v20.10.0/node-v20.10.0-linux-$RUNS_ON_AGENT_ARCH.tar.gz | sudo tar -xzf - -C /usr/local --strip-components=1
       - name: Environment Information
         run: npx envinfo

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,6 @@ install-test:
 
 install-stage:
 	AWS_PROFILE=runs-on-admin ./cloudformation/runs-on.sh --install --template-url=cloudformation/template.yaml --org=runs-on --stack-name=runs-on-stage --az=eu-west-1 --email=ops@runs-on.com
+
+logs-stage:
+	AWS_PROFILE=runs-on-admin awslogs get --aws-region eu-west-1 /aws/apprunner/RunsOnService-6Gwxsz1vjfMD/356d75069c2c4ec89b0e452c51778ce8/application -wGS -s 30m --timestamp

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ install-dev:
 
 install-test:
 	AWS_PROFILE=runs-on-admin ./cloudformation/runs-on.sh --install --template-url=cloudformation/template-dev.yaml --org=runs-on --stack-name=runs-on-test --az=us-east-1b --email=hey@cyrilrohr.com
+
+install-stage:
+	AWS_PROFILE=runs-on-admin ./cloudformation/runs-on.sh --install --template-url=cloudformation/template.yaml --org=runs-on --stack-name=runs-on-stage --az=eu-west-1 --email=ops@runs-on.com


### PR DESCRIPTION
Goal of this PR:

- setup CloudWatch agent on runner
- agent publishes CPU/RAM metric to CloudWatch (using instance profile)
- admin can see aggregated metrics in a CloudWatch dashboard, ideally filterable by repo / workflow