### PR TITLE
Explicitly require IMDSv2 connection on EC2 creation

### DIFF
--- a/src/ec2.js
+++ b/src/ec2.js
@@ -348,7 +348,11 @@ const createEC2Instance = async function ({
     }],
     IamInstanceProfile: {
       Arn: app.state.stack.outputs.instanceProfileArn
-    }
+    },
+    MetadataOptions: { // Specify IMDSv2
+      HttpTokens: "required",
+      HttpPutResponseHopLimit: 3,
+    },
   };
   // specifiy instance profile:
   // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-profiles

--- a/src/ec2.js
+++ b/src/ec2.js
@@ -352,7 +352,7 @@ const createEC2Instance = async function ({
     MetadataOptions: { // Specify IMDSv2
       HttpTokens: "required",
       HttpPutResponseHopLimit: 3,
-    },
+    }
   };
   // specifiy instance profile:
   // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-profiles


### PR DESCRIPTION
Taking a stab at #22 , though I'm not a JS expert by any means so please double-check my additions.

Resources: 
- https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ec2/command/RunInstancesCommand/
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances