### PR TITLE
Fleet support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ run-dev:
 
 install-dev:
 	AWS_PROFILE=runs-on-admin aws cloudformation deploy \
-		--disable-rollback --no-cli-pager --fail-on-empty-changeset \
+		--no-disable-rollback \
+		--no-cli-pager --fail-on-empty-changeset \
 		--stack-name runs-on-test \
 		--template-file ./cloudformation/template-dev.yaml \
 		--parameter-overrides GithubOrganization=runs-on AvailabilityZone=us-east-1a EmailAddress=ops+dev@runs-on.com LicenseKey=$(LICENSE_KEY) \
@@ -63,7 +64,8 @@ install-dev:
 
 install-test:
 	AWS_PROFILE=runs-on-admin aws cloudformation deploy \
-		--disable-rollback --no-cli-pager --fail-on-empty-changeset \
+		--disable-rollback \
+		--no-cli-pager --fail-on-empty-changeset \
 		--stack-name runs-on-test \
 		--template-file ./cloudformation/template.yaml \
 		--parameter-overrides GithubOrganization=runs-on AvailabilityZone=us-east-1b EmailAddress=ops+test@runs-on.com LicenseKey=$(LICENSE_KEY) \
@@ -82,4 +84,4 @@ install-stage:
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
 
 logs-stage:
-	AWS_PROFILE=runs-on-admin awslogs get --aws-region us-east-1 /aws/apprunner/RunsOnService-SPfhpcSJYhXM/aec9ac295e2f413db62d20d944dca07c/application -wGS -s 30m --timestamp
+	AWS_PROFILE=runs-on-admin awslogs get --aws-region us-east-1 /aws/apprunner/RunsOnService-SPfhpcSJYhXM/aec9ac295e2f413db62d20d944dca07c/application -wGS -s 300m --timestamp

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -1,27 +1,25 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: CloudFormation stack for https://runs-on.com
 
-Metadata: 
-  AWS::CloudFormation::Interface: 
-    ParameterGroups: 
-      - 
-        Label: 
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
           default: "Required Configuration"
-        Parameters: 
+        Parameters:
           - GithubOrganization
           - LicenseKey
           - EmailAddress
           - AvailabilityZone
           - SSHCidrRange
-      - 
-        Label: 
+      - Label:
           default: "Advanced Configuration"
-        Parameters: 
+        Parameters:
           - AppEc2QueueSize
           - AppCPU
           - AppMemory
     ParameterLabels:
-      GithubOrganization: 
+      GithubOrganization:
         default: "Your GitHub organization or personal name."
 
 Parameters:
@@ -60,73 +58,65 @@ Parameters:
     Type: Number
     Default: "256"
     Description: CPU units for RunsOn service (256 or higher)
-  
+
   AppMemory:
     Type: Number
     Default: "512"
     Description: Memory in MB for RunsOn service (512 or higher)
 
-Transform: 'AWS::LanguageExtensions'
-
 Mappings:
   App:
     Image:
       Tag: "v1.7.4-dev"
-  Networking:
-    AzSuffixToIndex:
-      1a: 0
-      1b: 1
-      1c: 2
-      1d: 3
-      1e: 4
-      1f: 5
-      1g: 6
-      2a: 0
-      2b: 1
-      2c: 2
-      2d: 3
-      2e: 4
-      2f: 5
-      2g: 6
-      3a: 0
-      3b: 1
-      3c: 2
-      3d: 3
-      3e: 4
-      3f: 5
-      3g: 6
-      4a: 0
-      4b: 1
-      4c: 2
-      4d: 3
-      4e: 4
-      4f: 5
-      4g: 6
 
 Resources:
   VPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 10.0.0.0/16
+      CidrBlock: 10.1.0.0/16
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
 
-  PublicSubnet:
+  PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId:
         Ref: VPC
-      AvailabilityZone:
-        Ref: AvailabilityZone
+      AvailabilityZone: !Select [0, !GetAZs ""]
       # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
       # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
-      CidrBlock: !Select [
-        !FindInMap [Networking, AzSuffixToIndex, !Select [ 2, !Split [ "-", !Ref AvailabilityZone]]],
-        !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]
-      ]
+      CidrBlock: !Select [0, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [1, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  PublicSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [2, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: "stack"
@@ -171,11 +161,70 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
 
-  SubnetRouteTableAssociation:
+  SubnetRouteTableAssociation1:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref PublicSubnet
+      SubnetId: !Ref PublicSubnet1
       RouteTableId: !Ref PublicRouteTable
+
+  SubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  SubnetRouteTableAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html
+  EC2FleetLaunchTemplateLinuxDefault:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub "${AWS::StackName}-linux-default"
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: 40
+              VolumeType: gp3
+              Throughput: 750
+              Iops: 3000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
+
+  EC2FleetLaunchTemplateLinuxLarge:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub "${AWS::StackName}-linux-large"
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: 80
+              VolumeType: gp3
+              Throughput: 1000
+              Iops: 4000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -200,6 +249,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "runs-on/purpose"
           Value: "config"
+
   S3BucketCache:
     Type: AWS::S3::Bucket
     Properties:
@@ -214,6 +264,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "runs-on/purpose"
           Value: "cache"
+
   EC2InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -244,11 +295,13 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+
   EC2InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
         - !Ref EC2InstanceRole
+
   RunsOnService:
     Type: AWS::AppRunner::Service
     Properties:
@@ -286,10 +339,6 @@ Resources:
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_BUCKET_CACHE
                 Value: !Ref S3BucketCache
-              - Name: RUNS_ON_PUBLIC_SUBNET_ID
-                Value: !Ref PublicSubnet
-              - Name: RUNS_ON_AVAILABILITY_ZONE
-                Value: !Ref AvailabilityZone
               - Name: RUNS_ON_SECURITY_GROUP_ID
                 Value: !Ref SecurityGroup
               - Name: RUNS_ON_INSTANCE_PROFILE_ARN
@@ -339,29 +388,25 @@ Resources:
                 Resource: !Ref AWS::StackId
               - Effect: Allow
                 Action:
-                  - ec2:RunInstances
-                Resource:
-                  - arn:aws:ec2:*:*:network-interface/*
-                  - arn:aws:ec2:*:*:volume/*
-                  - arn:aws:ec2:*:*:security-group/*
-                  - arn:aws:ec2:*::image/ami-*
-                  - Fn::Sub: arn:aws:ec2:*:*:subnet/${PublicSubnet}
-              - Effect: Allow
-                Action:
-                  - ec2:CreateTags
-                  - ec2:RunInstances
-                Resource: arn:aws:ec2:*:*:instance/*
+                  - ec2:CreateFleet
+                  - ec2:DeleteFleet
+                Resource: "*"
+              # - Effect: Allow
+              #   Action:
+              #     - ec2:CreateTags
+              #     - ec2:RunInstances
+              #   Resource: arn:aws:ec2:*:*:instance/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
                 Resource: !GetAtt EC2InstanceRole.Arn
-              - Effect: Allow
-                Action:
-                  - ec2:TerminateInstances
-                Resource: "arn:aws:ec2:*:*:instance/*"
-                Condition:
-                  StringEquals:
-                    "aws:ResourceTag/stack": !Ref AWS::StackName
+              # - Effect: Allow
+              #   Action:
+              #     - ec2:TerminateInstances
+              #   Resource: "arn:aws:ec2:*:*:instance/*"
+              #   Condition:
+              #     StringEquals:
+              #       "aws:ResourceTag/stack": !Ref AWS::StackName
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -378,10 +423,10 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: Alerts when the daily usage of the RunsOn service exceeds 6000 minutes
-      Namespace: RunsOn 
+      Namespace: RunsOn
       MetricName: minutes
-      Statistic: Sum   # Choose the appropriate statistic (e.g., Sum, Average, Maximum)
-      Period: 86400   # Set to 24 hours for 1-day periods (adjust as needed)
+      Statistic: Sum # Choose the appropriate statistic (e.g., Sum, Average, Maximum)
+      Period: 86400 # Set to 24 hours for 1-day periods (adjust as needed)
       EvaluationPeriods: 1
       Threshold: 40
       ComparisonOperator: GreaterThanThreshold
@@ -403,10 +448,10 @@ Resources:
     Properties:
       Protocol: email
       TopicArn: !Ref AlertTopic
-      Endpoint: !If [EmailProvided, !Ref EmailAddress, '']
+      Endpoint: !If [EmailProvided, !Ref EmailAddress, ""]
 
 Conditions:
-  EmailProvided: !Not [!Equals [!Ref EmailAddress, '']]
+  EmailProvided: !Not [!Equals [!Ref EmailAddress, ""]]
 
 Outputs:
   RunsOnEntryPoint:
@@ -421,15 +466,9 @@ Outputs:
   RunsOnLicenseKey:
     Description: License key
     Value: !Ref LicenseKey
-  RunsOnAvailabilityZone:
-    Description: Availability zone
-    Value: !Ref AvailabilityZone
   RunsOnInstanceProfileArn:
     Description: Runner instance profile
     Value: !GetAtt EC2InstanceProfile.Arn
-  RunsOnPublicSubnetId:
-    Description: Public subnet for launching runners
-    Value: !Ref PublicSubnet
   RunsOnSecurityGroupId:
     Description: Security group for runners
     Value: !Ref SecurityGroup

--- a/src/apps/main.js
+++ b/src/apps/main.js
@@ -27,8 +27,10 @@ module.exports = async (app, { getRouter }) => {
     return;
   }
 
+  const router = getRouter();
+
   // bind webhook path with correct credentials
-  getRouter().use(
+  router.use(
     "/",
     createWebhooksMiddleware(app.webhooks, { path: "/", log: app.log })
   );

--- a/src/config.js
+++ b/src/config.js
@@ -55,4 +55,26 @@ async function update(filePath, prefix = "runs-on") {
   }
 }
 
-module.exports = { update, fetch };
+async function uploadBootstrapScript(target, content) {
+  const { s3BucketCache } = await stack.fetchOutputs();
+
+  const uploadParams = {
+    Bucket: s3BucketCache,
+    Key: target,
+    Body: content,
+    ACL: "private",
+  };
+
+  try {
+    const response = await s3Client.send(new PutObjectCommand(uploadParams));
+    logger.info(
+      `Bootstrap file uploaded successfully at ${s3BucketCache}/${target}`
+    );
+  } catch (error) {
+    logger.error(
+      `Error uploading file at ${s3BucketCache}/${target} - ${error}`
+    );
+  }
+}
+
+module.exports = { update, fetch, uploadBootstrapScript };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,7 @@
 const Handlebars = require("handlebars");
 const fs = require("fs");
 const path = require("path");
+const { RUNNERS } = require("./runners");
 
 Handlebars.registerHelper("round", function (value) {
   if (!value) return "N/A";
@@ -31,7 +32,7 @@ const RUNS_ON_ENV = process.env["RUNS_ON_ENV"] || "prod";
 const EMAIL_COSTS_TEMPLATE = Handlebars.compile(
   fs
     .readFileSync(
-      path.join(__dirname, "..", "data", "email_costs_template.md.hbs")
+      path.join(__dirname, "..", "..", "data", "email_costs_template.md.hbs")
     )
     .toString()
 );
@@ -79,7 +80,7 @@ const USER_DATA = {
   [PLATFORM_LINUX]: Handlebars.compile(
     fs
       .readFileSync(
-        path.join(__dirname, "..", "data", "user_data", "linux.sh.hbs")
+        path.join(__dirname, "..", "..", "data", "user_data", "linux.sh.hbs")
       )
       .toString()
   ),
@@ -155,64 +156,6 @@ const RUNNER_ATTRIBUTES = [
   "image",
 ];
 
-// TODO: macos - https://aws.amazon.com/ec2/faqs/#macos_workloads, 24h min dedicated host
-const RUNNERS = {
-  "1cpu-linux": {
-    cpu: 1,
-    family: ["m7a", "m7g", "m7i"],
-    // pricing: [0.000966, 0.000383],      // t3a
-    pricing: [0.000966, 0.00038], // m7a
-  },
-  "2cpu-linux": {
-    cpu: 2,
-    family: ["m7a", "m7g", "m7i"],
-    // pricing: [0.001253, 0.000505],      // t3a
-    pricing: [0.001932, 0.000783], // m7a
-  },
-  "4cpu-linux": {
-    cpu: 4,
-    family: ["m7a", "m7g", "m7i", "c7a", "c7g"],
-    // pricing: [0.002507, 0.001115],      // t3a
-    pricing: [0.003864, 0.00185], // c7a
-  },
-  "8cpu-linux": {
-    cpu: 8,
-    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
-    throughput: 750,
-    iops: 4000,
-    // pricing: [0.005013, 0.002325],      // t3a
-    pricing: [0.006843, 0.003097], // c7a
-  },
-  "16cpu-linux": {
-    cpu: 16,
-    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
-    throughput: 750,
-    iops: 4000,
-    pricing: [0.013685, 0.006415], // c7a
-  },
-  "32cpu-linux": {
-    cpu: 32,
-    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
-    throughput: 750,
-    iops: 4000,
-    pricing: [0.027371, 0.012677], // c7a
-  },
-  "48cpu-linux": {
-    cpu: 48,
-    throughput: 1000,
-    iops: 4000,
-    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
-    pricing: [0.041056, 0.016577], // c7a
-  },
-  "64cpu-linux": {
-    cpu: 64,
-    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
-    throughput: 1000,
-    iops: 4000,
-    pricing: [0.054741, 0.020535], // c7a
-  },
-};
-
 const MINUTES_PER_MONTH = 60 * 24 * 30;
 
 Object.keys(RUNNERS).forEach((key) => {
@@ -240,7 +183,7 @@ Object.keys(RUNNERS).forEach((key) => {
   }
 });
 
-const DEFAULT_RUNNER_SPEC_KEY = "2cpu-linux";
+const DEFAULT_RUNNER_SPEC_KEY = "2cpu-linux-x64";
 const DEFAULT_RUNNER_SPEC = RUNNERS[DEFAULT_RUNNER_SPEC_KEY];
 
 let RUNS_ON_EC2_QUEUE_SIZE = Number(process.env["RUNS_ON_EC2_QUEUE_SIZE"]);

--- a/src/constants/runners.js
+++ b/src/constants/runners.js
@@ -1,0 +1,172 @@
+const RUNNERS = {
+  "1cpu-linux-x64": {
+    cpu: 1,
+    family: ["m7a", "m6a"],
+    image: "ubuntu22-full-x64",
+    pricing: [0.000966, 0.00036], // m7a
+  },
+  "2cpu-linux-x64": {
+    cpu: 2,
+    family: ["m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    pricing: [0.001596, 0.000712], // m7i-flex
+  },
+  "4cpu-linux-x64": {
+    cpu: 4,
+    family: ["m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    pricing: [0.003192, 0.001473], // m7i-flex
+  },
+  "8cpu-linux-x64": {
+    cpu: 8,
+    family: ["c7i", "c7a", "m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.00595, 0.002678], // c7i
+  },
+  "16cpu-linux-x64": {
+    cpu: 16,
+    family: ["c7i", "c7a", "m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.0119, 0.005777], // c7i
+  },
+  "32cpu-linux-x64": {
+    cpu: 32,
+    family: ["c7i", "c7a", "m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.0238, 0.010733], // c7i
+  },
+  "48cpu-linux-x64": {
+    cpu: 48,
+    family: ["c7i", "c7a", "m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    throughput: 1000,
+    iops: 4000,
+    pricing: [0.0357, 0.014802], // c7i
+  },
+  "64cpu-linux-x64": {
+    cpu: 64,
+    family: ["c7i", "c7a", "m7i", "m7a"],
+    image: "ubuntu22-full-x64",
+    throughput: 1000,
+    iops: 4000,
+    pricing: [0.0476, 0.019587], // c7i
+  },
+  "1cpu-linux-arm64": {
+    cpu: 1,
+    family: ["m7g", "t4g.medium"],
+    image: "ubuntu22-full-arm64",
+    pricing: [0.00068, 0.00029], // m7g
+  },
+  "2cpu-linux-arm64": {
+    cpu: 2,
+    family: ["m7g", "t4g.large"],
+    pricing: [0.00136, 0.000575], // m7g
+  },
+  "4cpu-linux-arm64": {
+    cpu: 4,
+    family: ["m7g", "t4g"],
+    image: "ubuntu22-full-arm64",
+    pricing: [0.00272, 0.001042], // m7g
+  },
+  "8cpu-linux-arm64": {
+    cpu: 8,
+    family: ["c7g", "m7g"],
+    image: "ubuntu22-full-arm64",
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.004833, 0.00193], // c7g
+  },
+  "16cpu-linux-arm64": {
+    cpu: 16,
+    family: ["c7g", "m7g"],
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.009667, 0.00415], // c7g
+  },
+  "32cpu-linux-arm64": {
+    cpu: 32,
+    family: ["c7g", "m7g"],
+    image: "ubuntu22-full-arm64",
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.019333, 0.00885], // c7g
+  },
+  "48cpu-linux-arm64": {
+    cpu: 48,
+    throughput: 1000,
+    iops: 4000,
+    family: ["c7g", "m7g"],
+    pricing: [0.029, 0.011742], // c7g
+  },
+  "64cpu-linux-arm64": {
+    cpu: 64,
+    family: ["c7g", "m7g"],
+    image: "ubuntu22-full-arm64",
+    throughput: 1000,
+    iops: 4000,
+    pricing: [0.038667, 0.0151], // c7g
+  },
+  // LEGACY
+  "1cpu-linux": {
+    cpu: 1,
+    family: ["m7a", "m7g", "m7i"],
+    // pricing: [0.000966, 0.000383],      // t3a
+    pricing: [0.000966, 0.00038], // m7a
+  },
+  "2cpu-linux": {
+    cpu: 2,
+    family: ["m7a", "m7g", "m7i"],
+    // pricing: [0.001253, 0.000505],      // t3a
+    pricing: [0.001932, 0.000783], // m7a
+  },
+  "4cpu-linux": {
+    cpu: 4,
+    family: ["m7a", "m7g", "m7i", "c7a", "c7g"],
+    // pricing: [0.002507, 0.001115],      // t3a
+    pricing: [0.003864, 0.00185], // c7a
+  },
+  "8cpu-linux": {
+    cpu: 8,
+    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
+    throughput: 750,
+    iops: 4000,
+    // pricing: [0.005013, 0.002325],      // t3a
+    pricing: [0.006843, 0.003097], // c7a
+  },
+  "16cpu-linux": {
+    cpu: 16,
+    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.013685, 0.006415], // c7a
+  },
+  "32cpu-linux": {
+    cpu: 32,
+    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
+    throughput: 750,
+    iops: 4000,
+    pricing: [0.027371, 0.012677], // c7a
+  },
+  "48cpu-linux": {
+    cpu: 48,
+    throughput: 1000,
+    iops: 4000,
+    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
+    pricing: [0.041056, 0.016577], // c7a
+  },
+  "64cpu-linux": {
+    cpu: 64,
+    family: ["c7a", "c7g", "m7i", "m7a", "m7g"],
+    throughput: 1000,
+    iops: 4000,
+    pricing: [0.054741, 0.020535], // c7a
+  },
+};
+
+module.exports = { RUNNERS };

--- a/src/constants/runners.js
+++ b/src/constants/runners.js
@@ -1,19 +1,19 @@
 const RUNNERS = {
   "1cpu-linux-x64": {
     cpu: 1,
-    family: ["m7a", "m6a"],
+    family: ["m7a", "m7i"],
     image: "ubuntu22-full-x64",
     pricing: [0.000966, 0.00036], // m7a
   },
   "2cpu-linux-x64": {
     cpu: 2,
-    family: ["m7i", "m7a"],
+    family: ["m7a", "m7i"],
     image: "ubuntu22-full-x64",
     pricing: [0.001596, 0.000712], // m7i-flex
   },
   "4cpu-linux-x64": {
     cpu: 4,
-    family: ["m7i", "m7a"],
+    family: ["m7a", "m7i"],
     image: "ubuntu22-full-x64",
     pricing: [0.003192, 0.001473], // m7i-flex
   },
@@ -66,6 +66,7 @@ const RUNNERS = {
   "2cpu-linux-arm64": {
     cpu: 2,
     family: ["m7g", "t4g.large"],
+    image: "ubuntu22-full-arm64",
     pricing: [0.00136, 0.000575], // m7g
   },
   "4cpu-linux-arm64": {

--- a/src/costs.js
+++ b/src/costs.js
@@ -97,6 +97,7 @@ async function sendEmailCosts() {
 function sanitizedTagValueFor(tags, key) {
   return (tags.find((tag) => tag.Key === key)?.Value || "unknown")
     .replace(/[^\x00-\x7F]/g, "")
+    .substring(0, 250)
     .trim();
 }
 

--- a/src/license.js
+++ b/src/license.js
@@ -45,7 +45,7 @@ class License {
           );
         }
       },
-      stack.devMode ? 30 * 1000 : 72 * 3600 * 1000
+      stack.devMode ? 600 * 1000 : 72 * 3600 * 1000
     );
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,6 +130,13 @@ function base64Scripts(scripts = []) {
     .map((script) => Buffer.from(script).toString("base64"));
 }
 
+function sanitizedAwsValue(value) {
+  return (value || "")
+    .replace(/[^\x00-\x7F]/g, "")
+    .substring(0, 250)
+    .trim();
+}
+
 module.exports = {
   base64Scripts,
   flatMapInput,
@@ -139,4 +146,5 @@ module.exports = {
   sanitizeImageSpec,
   isStringFloat,
   objToArray,
+  sanitizedAwsValue,
 };

--- a/src/workflow_job.js
+++ b/src/workflow_job.js
@@ -158,12 +158,12 @@ class WorkflowJob {
       );
     }
 
-    this.instanceTypes = await this.findMatchingInstanceTypes();
-    if (this.instanceTypes.length === 0) {
-      throw new Error(
-        `❌ No instance types found for ${JSON.stringify(this.runnerSpec)}`
-      );
-    }
+    // this.instanceTypes = await this.findMatchingInstanceTypes();
+    // if (this.instanceTypes.length === 0) {
+    //   throw new Error(
+    //     `❌ No instance types found for ${JSON.stringify(this.runnerSpec)}`
+    //   );
+    // }
 
     this.launchTemplate = ec2.generateLaunchTemplate({
       stackOutputs: await stack.fetchOutputs(),


### PR DESCRIPTION
Replaces RunInstances call with CreateFleet:

- multi-az support (3 AZ by default for the stack)
- `capacity-optimized-prioritized` allocation
- modify launch sequence so that instance retrieves boot details from the S3 bucket (no more user-data)