### PR TITLE
Fix throttling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.7.4
+VERSION=v1.7.5
 VERSION_DEV=$(VERSION)-dev
 MAJOR_VERSION=v1
 SHELL:=/bin/bash
@@ -82,4 +82,4 @@ install-stage:
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
 
 logs-stage:
-	AWS_PROFILE=runs-on-admin awslogs get --aws-region us-east-1 /aws/apprunner/RunsOnService-SPfhpcSJYhXM/aec9ac295e2f413db62d20d944dca07c/application -wGS -s 30m --timestamp
+	AWS_PROFILE=runs-on-admin awslogs get -i 3 --aws-region us-east-1 /aws/apprunner/RunsOnService-SPfhpcSJYhXM/aec9ac295e2f413db62d20d944dca07c/application -wGS -s 30m --timestamp

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -71,7 +71,7 @@ Transform: 'AWS::LanguageExtensions'
 Mappings:
   App:
     Image:
-      Tag: "v1.7.4-dev"
+      Tag: "v1.7.5-dev"
   Networking:
     AzSuffixToIndex:
       1a: 0

--- a/src/apps/main.js
+++ b/src/apps/main.js
@@ -4,6 +4,27 @@ const {
 const stack = require("../stack").getInstance();
 const alerting = require("../alerting");
 const WorkflowJob = require("../workflow_job");
+const pThrottle = require("p-throttle");
+
+const { RUNS_ON_EC2_QUEUE_SIZE } = require("../constants");
+
+const scheduleWorkflowThrottled = pThrottle({
+  limit: RUNS_ON_EC2_QUEUE_SIZE,
+  interval: 1700,
+});
+
+const terminateWorkflowThrottled = pThrottle({
+  limit: RUNS_ON_EC2_QUEUE_SIZE,
+  interval: 1700,
+});
+
+const workflowJobScheduleQueue = scheduleWorkflowThrottled((workflowJob) =>
+  workflowJob.schedule()
+);
+
+const workflowJobCompleteQueue = terminateWorkflowThrottled((workflowJob) =>
+  workflowJob.complete()
+);
 
 module.exports = async (app, { getRouter }) => {
   app.log.info("🎉 Yay, the app was loaded!");
@@ -27,8 +48,10 @@ module.exports = async (app, { getRouter }) => {
     return;
   }
 
+  const router = getRouter();
+
   // bind webhook path with correct credentials
-  getRouter().use(
+  router.use(
     "/",
     createWebhooksMiddleware(app.webhooks, { path: "/", log: app.log })
   );
@@ -40,7 +63,7 @@ module.exports = async (app, { getRouter }) => {
 
   app.on("workflow_job.queued", async (context) => {
     const workflowJob = new WorkflowJob(context);
-    workflowJob.schedule();
+    workflowJobScheduleQueue(workflowJob);
   });
 
   app.on("workflow_job.in_progress", async (context) => {
@@ -50,6 +73,6 @@ module.exports = async (app, { getRouter }) => {
 
   app.on("workflow_job.completed", async (context) => {
     const workflowJob = new WorkflowJob(context);
-    workflowJob.complete();
+    workflowJobCompleteQueue(workflowJob);
   });
 };


### PR DESCRIPTION
Code was incorrectly await'ing on the queue, so moved the entire workflow within the queue, so that we can stop needing awaiting on the EC2 response. In any case, the EC2 RunInstances call is the one taking the most time so this should not change a lot of things.