### PR TITLE
v2.5.0

### DIFF
--- a/.github/workflows/test-failures.yml
+++ b/.github/workflows/test-failures.yml
@@ -6,18 +6,36 @@ on:
       env:
         description: "env"
         required: true
-        default: "prod"
+        default: "production"
 
 permissions:
   contents: read
 
 jobs:
   test-preinstall-ko:
-    runs-on: runs-on,runner=preinstall-ko,env=${{ inputs.env || 'prod' }}
+    runs-on: runs-on,runner=preinstall-ko,env=${{ inputs.env || 'production' }}
     steps:
-      - run: echo Should never run
+      - run: |
+          echo "Should never run. Preinstall failed"
+          exit 1
 
   test-runner-unknown:
-    runs-on: runs-on,runner=unknown,env=${{ inputs.env || 'prod' }}
+    runs-on: runs-on,runner=unknown,env=${{ inputs.env || 'production' }}
     steps:
-      - run: echo Should never run
+      - run: |
+          echo "Should never run. Runner not found"
+          exit 1
+
+  test-env-unsupported:
+    runs-on: runs-on,runner=2cpu-linux-x64,env=unknown
+    steps:
+      - run: |
+          echo "Should never run. Env not supported"
+          exit 1
+
+  test-private-not-supported:
+    runs-on: runs-on,runner=2cpu-linux-x64,private=true,env=production
+    steps:
+      - run: |
+          echo "Should never run. Private runners are not supported on this env"
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       env:
         description: "env"
         required: true
-        default: "prod"
+        default: "production"
   push:
     branches:
       - main
@@ -22,7 +22,7 @@ jobs:
         - runs-on
         - runner=2cpu-linux-x64
         - tag=env-test-protected
-        - env=${{ inputs.env || 'prod' }}
+        - env=${{ inputs.env || 'production' }}
     environment:
       name: test
       url: https://protected.example.com
@@ -37,7 +37,7 @@ jobs:
         - runs-on
         - runner=2cpu-linux-x64
         - tag=env-test-no-protection
-        - env=${{ inputs.env || 'prod' }}
+        - env=${{ inputs.env || 'production' }}
     environment:
       name: test-no-protection
       url: https://not-protected.example.com
@@ -47,12 +47,12 @@ jobs:
       - run: echo Hello world
 
   test-preinstall-ok:
-    runs-on: runs-on,runner=preinstall-ok,env=${{ inputs.env || 'prod' }}
+    runs-on: runs-on,runner=preinstall-ok,env=${{ inputs.env || 'production' }}
     steps:
       - run: echo Hello world
 
   test-ssd-mount:
-    runs-on: runs-on,runner=2cpu-linux-arm64,family=c7gd,env=${{ inputs.env || 'prod' }}
+    runs-on: runs-on,runner=2cpu-linux-arm64,family=c7gd,env=${{ inputs.env || 'production' }}
     steps:
       - name: Show disk setup
         run: |
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
 
   test-metal:
-    runs-on: runs-on,family=c7g.metal,image=ubuntu22-full-arm64,env=${{ inputs.env || 'prod' }}
+    runs-on: runs-on,family=c7g.metal,image=ubuntu22-full-arm64,env=${{ inputs.env || 'production' }}
     steps:
       - run: echo Hello world
 
@@ -83,7 +83,7 @@ jobs:
     runs-on:
       labels:
         - ${{ matrix.runner }}
-        - env=${{ inputs.env || 'prod' }}
+        - env=${{ inputs.env || 'production' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ WORKDIR /app
 # Copy the binary to the production image from the builder stage.
 COPY --from=build /app/dist /app/dist
 
-ENV RUNS_ON_ENV="prod"
 ENV RUNS_ON_AGENT_FOLDER="/app/dist"
 
 CMD ["/app/dist/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,3 @@ ENV RUNS_ON_ENV="prod"
 ENV RUNS_ON_AGENT_FOLDER="/app/dist"
 
 CMD ["/app/dist/server"]
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v2.4.0
+VERSION=v2.5.0
 VERSION_DEV=$(VERSION)-dev
 MAJOR_VERSION=v2
 REGISTRY=public.ecr.aws/c5h5o9k1/runs-on/runs-on
@@ -69,6 +69,15 @@ install-dev:
 		--template-file ./cloudformation/template-dev.yaml \
 		--parameter-overrides GithubOrganization=runs-on EmailAddress=ops+dev@runs-on.com Private=$(PRIVATE) EC2InstanceCustomPolicy=arn:aws:iam::756351362063:policy/my-custom-policy DefaultAdmins="crohr,github" RunnerLargeDiskSize=120 LicenseKey=$(LICENSE_KEY) AlertTopicSubscriptionHttpsEndpoint=$(ALERT_TOPIC_SUBSCRIPTION_HTTPS_ENDPOINT) ServerPassword=$(SERVER_PASSWORD) \
 		--capabilities CAPABILITY_IAM
+
+install-dev-peering:
+	AWS_PROFILE=runs-on-admin aws cloudformation deploy \
+		--no-disable-rollback \
+		--no-cli-pager --fail-on-empty-changeset \
+		--stack-name runs-on-dev-peering \
+		--region=us-east-1 \
+		--template-file ./cloudformation/vpc-peering.yaml \
+		--parameter-overrides RunsOnStackName=runs-on DestinationVpcId=vpc-02c66d4adb655aa2f
 
 show-dev:
 	@URL=$$(AWS_PROFILE=runs-on-admin aws cloudformation describe-stacks \

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ dev: login
 # generates a stage release
 stage: build-push
 	aws s3 cp ./cloudformation/template-$(VERSION).yaml s3://runs-on/cloudformation/
+	aws s3 cp ./cloudformation/vpc-peering.yaml s3://runs-on/cloudformation/
 
 # promotes the stage release as latest production version
 promote: check tag stage
@@ -67,7 +68,7 @@ install-dev:
 		--stack-name runs-on \
 		--region=us-east-1 \
 		--template-file ./cloudformation/template-dev.yaml \
-		--parameter-overrides GithubOrganization=runs-on EmailAddress=ops+dev@runs-on.com Private=$(PRIVATE) EC2InstanceCustomPolicy=arn:aws:iam::756351362063:policy/my-custom-policy DefaultAdmins="crohr,github" RunnerLargeDiskSize=120 LicenseKey=$(LICENSE_KEY) AlertTopicSubscriptionHttpsEndpoint=$(ALERT_TOPIC_SUBSCRIPTION_HTTPS_ENDPOINT) ServerPassword=$(SERVER_PASSWORD) Environment=dev \
+		--parameter-overrides GithubOrganization=runs-on EmailAddress=ops+dev@runs-on.com Private=$(PRIVATE) EC2InstanceCustomPolicy=arn:aws:iam::756351362063:policy/my-custom-policy DefaultAdmins="crohr,github" RunnerLargeDiskSize=120 LicenseKey=$(LICENSE_KEY) AlertTopicSubscriptionHttpsEndpoint=$(ALERT_TOPIC_SUBSCRIPTION_HTTPS_ENDPOINT) ServerPassword=$(SERVER_PASSWORD) Environment=dev RunnerCustomTags="my/tag=my/value3" \
 		--capabilities CAPABILITY_IAM
 
 install-dev-peering:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install-dev:
 		--stack-name runs-on \
 		--region=us-east-1 \
 		--template-file ./cloudformation/template-dev.yaml \
-		--parameter-overrides GithubOrganization=runs-on EmailAddress=ops+dev@runs-on.com Private=$(PRIVATE) EC2InstanceCustomPolicy=arn:aws:iam::756351362063:policy/my-custom-policy DefaultAdmins="crohr,github" RunnerLargeDiskSize=120 LicenseKey=$(LICENSE_KEY) AlertTopicSubscriptionHttpsEndpoint=$(ALERT_TOPIC_SUBSCRIPTION_HTTPS_ENDPOINT) ServerPassword=$(SERVER_PASSWORD) \
+		--parameter-overrides GithubOrganization=runs-on EmailAddress=ops+dev@runs-on.com Private=$(PRIVATE) EC2InstanceCustomPolicy=arn:aws:iam::756351362063:policy/my-custom-policy DefaultAdmins="crohr,github" RunnerLargeDiskSize=120 LicenseKey=$(LICENSE_KEY) AlertTopicSubscriptionHttpsEndpoint=$(ALERT_TOPIC_SUBSCRIPTION_HTTPS_ENDPOINT) ServerPassword=$(SERVER_PASSWORD) Environment=dev \
 		--capabilities CAPABILITY_IAM
 
 install-dev-peering:
@@ -79,12 +79,14 @@ install-dev-peering:
 		--template-file ./cloudformation/vpc-peering.yaml \
 		--parameter-overrides RunsOnStackName=runs-on DestinationVpcId=vpc-02c66d4adb655aa2f
 
+logs-dev:
+	AWS_PROFILE=runs-on-admin awslogs get --aws-region us-east-1 /aws/apprunner/RunsOnService-NWAiVjCasSdH/5eaf2c1bd7ab4baaacfde8b7dd574fda/application -i 2 -w -s 120m --timestamp
+
 show-dev:
-	@URL=$$(AWS_PROFILE=runs-on-admin aws cloudformation describe-stacks \
+	AWS_PROFILE=runs-on-admin aws cloudformation describe-stacks \
 		--stack-name runs-on \
 		--region=us-east-1 \
-		--query "Stacks[0].Outputs[?OutputKey=='RunsOnEntryPoint'].OutputValue" \
-		--output text) && echo "https://$${URL}"
+		--query "Stacks[0].Outputs[?OutputKey=='RunsOnEntryPoint' || OutputKey=='RunsOnService'].[OutputKey,OutputValue]"
 
 # Install with the VERSION template (temporary install)
 install-test:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ show-dev:
 	AWS_PROFILE=runs-on-admin aws cloudformation describe-stacks \
 		--stack-name runs-on \
 		--region=us-east-1 \
-		--query "Stacks[0].Outputs[?OutputKey=='RunsOnEntryPoint' || OutputKey=='RunsOnService'].[OutputKey,OutputValue]"
+		--query "Stacks[0].Outputs[?OutputKey=='RunsOnEntryPoint' || OutputKey=='RunsOnService' || OutputKey=='RunsOnPrivate' || OutputKey=='RunsOnEgressStaticIP'].[OutputKey,OutputValue]"
 
 # Install with the VERSION template (temporary install)
 install-test:

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -28,6 +28,7 @@ Metadata:
       - Label:
           default: "Advanced app configuration [optional]"
         Parameters:
+          - Environment
           - RunnerDefaultDiskSize
           - RunnerDefaultVolumeThroughput
           - RunnerLargeDiskSize
@@ -56,6 +57,11 @@ Parameters:
     Type: String
     Description: Email address for cost and alert reports. You must confirm the subscription by clicking the link in the email that you will receive after creating the stack.
     MinLength: 1
+
+  Environment:
+    Type: String
+    Default: "production"
+    Description: "Environment for the RunsOn service. You can create multiple RunsOn installations and set this parameter to different values. And then target a single installation by setting the `env=ENV_NAME` label in the `runs-on:` definition in your GitHub Actions workflow. If no label is set, the `production` environment is targeted. Most users only need the default `production` environment."
 
   AlertTopicSubscriptionHttpsEndpoint:
     Type: String
@@ -814,6 +820,8 @@ Resources:
           ImageConfiguration:
             Port: 8080
             RuntimeEnvironmentVariables:
+              - Name: RUNS_ON_ENV
+                Value: !Ref Environment
               - Name: RUNS_ON_STACK_NAME
                 Value: !Ref AWS::StackName
               - Name: RUNS_ON_ORG

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -11,13 +11,14 @@ Metadata:
           - LicenseKey
           - EmailAddress
       - Label:
-          default: "Security settings [optional]"
+          default: "Security and Network settings [optional]"
         Parameters:
-          - ServerPassword
+          - VpcCidrBlock
           - Private
-          - DefaultAdmins
           - SSHCidrRange
           - EC2InstanceCustomPolicy
+          - ServerPassword
+          - DefaultAdmins
       - Label:
           default: "Alert settings [optional]"
         Parameters:
@@ -53,7 +54,7 @@ Parameters:
 
   EmailAddress:
     Type: String
-    Description: Email address for cost and alert reports.
+    Description: Email address for cost and alert reports. You must confirm the subscription by clicking the link in the email that you will receive after creating the stack.
     MinLength: 1
 
   AlertTopicSubscriptionHttpsEndpoint:
@@ -61,10 +62,15 @@ Parameters:
     Description: HTTPS endpoint for cost and alert reports.
     Default: ""
 
+  VpcCidrBlock:
+    Type: String
+    Description: CIDR block for the VPC. Updating this value after creation will require deleting the stack and recreating it.
+    Default: 10.1.0.0/16
+
   SSHCidrRange:
     Type: String
     Default: 0.0.0.0/0
-    Description: CIDR range for SSH access (mainly useful when Private=false). By default, only repository collaborators with admin permission will be able to SSH into the runner instances.
+    Description: CIDR range for SSH access. By default, only repository collaborators with admin permission will be able to SSH into the runner instances.
     MinLength: 1
 
   Private:
@@ -73,7 +79,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: "Enable (true) or disable (false) private subnets. Note that enabling will create 1 managed NAT gateway, with the corresponding costs."
+    Description: "Enable (true) or disable (false) private networking. If enabled, you will be able to launch runners in private subnets, and they will get a static egress IP. Note that enabling it will create 1 managed NAT gateway, with the corresponding costs. More details at https://runs-on.com/features/static-ips/."
 
   DefaultAdmins:
     Type: String
@@ -161,7 +167,7 @@ Parameters:
 Mappings:
   App:
     Image:
-      Tag: "v2.4.0-dev"
+      Tag: "v2.5.0-dev"
 
 Conditions:
   EmailProvided: !Not [!Equals [!Ref EmailAddress, ""]]
@@ -175,12 +181,14 @@ Resources:
   VPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 10.1.0.0/16
+      CidrBlock: !Ref VpcCidrBlock
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-VPC
 
   PrivateSubnet1RouteTable:
     Type: AWS::EC2::RouteTable
@@ -189,6 +197,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet1RouteTable
 
   PrivateSubnet2RouteTable:
     Type: AWS::EC2::RouteTable
@@ -197,6 +207,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2RouteTable
 
   PrivateSubnet3RouteTable:
     Type: AWS::EC2::RouteTable
@@ -205,6 +217,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3RouteTable
 
   PrivateSubnet1Route:
     Condition: HasPrivateSubnet
@@ -271,6 +285,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2
 
   PrivateSubnet3:
     Type: AWS::EC2::Subnet
@@ -283,6 +299,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3
 
   PrivateSubnetGateway1:
     Condition: HasPrivateSubnet
@@ -294,6 +312,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnetGateway1
 
   ElasticIP1:
     Condition: HasPrivateSubnet
@@ -303,6 +323,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-ElasticIP1
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
@@ -317,6 +339,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet1
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
@@ -331,6 +355,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet2
 
   PublicSubnet3:
     Type: AWS::EC2::Subnet
@@ -345,6 +371,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet3
 
   S3VpcEndpoint:
     Type: AWS::EC2::VPCEndpoint
@@ -365,6 +393,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-InternetGateway
 
   AttachGateway:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -379,6 +409,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicRouteTable
 
   PublicRoute:
     Type: AWS::EC2::Route
@@ -662,7 +694,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:
-        # !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy, "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"], ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]]
         !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy], []]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -1023,6 +1054,37 @@ Outputs:
   RunsOnRegion:
     Description: AWS region
     Value: !Ref AWS::Region
+  RunsOnVPCId:
+    Description: VPC ID
+    Value: !Ref VPC
+    Export:
+      Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnPublicRouteTableId:
+    Description: Public Route Table ID
+    Value: !Ref PublicRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PublicRouteTableId"
+  RunsOnPrivateRouteTable1Id:
+    Description: Private Route Table 1 ID
+    Value: !Ref PrivateSubnet1RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable1Id"
+  RunsOnPrivateRouteTable2Id:
+    Description: Private Route Table 2 ID
+    Value: !Ref PrivateSubnet2RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable2Id"
+  RunsOnPrivateRouteTable3Id:
+    Description: Private Route Table 3 ID
+    Value: !Ref PrivateSubnet3RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable3Id"
+  RunsOnEgressStaticIP:
+    Description: Static IP for egress traffic (if configured)
+    Value: !If
+      - HasPrivateSubnet
+      - !Ref ElasticIP1
+      - "-"
   RunsOnPublicSubnet1:
     Description: Public subnet 1
     Value: !Ref PublicSubnet1

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -29,6 +29,7 @@ Metadata:
           default: "Advanced app configuration [optional]"
         Parameters:
           - Environment
+          - RunnerCustomTags
           - RunnerDefaultDiskSize
           - RunnerDefaultVolumeThroughput
           - RunnerLargeDiskSize
@@ -143,6 +144,11 @@ Parameters:
     MinValue: 125
     MaxValue: 1000
     Description: Volume throughput in MiB/s for large runners (helps with faster boot times, but costs more).
+
+  RunnerCustomTags:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: "Optional custom tags for the runner instances (e.g. 'key1=value1,key2=value2'). Tag keys can only use letters (a-z, A-Z), numbers (0-9), and the following characters: + - = . , _ : @ (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions)"
 
   CostReportsEnabled:
     Type: String
@@ -830,6 +836,8 @@ Resources:
                 Value: !FindInMap [App, Image, Tag]
               - Name: RUNS_ON_LICENSE_KEY
                 Value: !Ref LicenseKey
+              - Name: RUNS_ON_RUNNER_CUSTOM_TAGS
+                Value: !Join [",", !Ref RunnerCustomTags]
               - Name: RUNS_ON_BUCKET_CONFIG
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_BUCKET_CACHE
@@ -1067,6 +1075,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnVpcCidrBlock:
+    Description: VPC CIDR block
+    Value: !Ref VpcCidrBlock
+    Export:
+      Name: !Sub "${AWS::StackName}-VpcCidrBlock"
   RunsOnPublicRouteTableId:
     Description: Public Route Table ID
     Value: !Ref PublicRouteTable
@@ -1120,6 +1133,9 @@ Outputs:
   RunsOnRunnerLargeDiskSize:
     Description: Large disk size for runners
     Value: !Ref RunnerLargeDiskSize
+  RunsOnRunnerCustomTags:
+    Description: Custom tags for runners
+    Value: !Join [",", !Ref RunnerCustomTags]
   RunsOnInstanceProfileArn:
     Description: Runner instance profile ARN
     Value: !GetAtt EC2InstanceProfile.Arn

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -73,7 +73,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: "Enable (true) or disable (false) private subnets. Note that enabling will create 3 managed NAT gateways, with the corresponding costs."
+    Description: "Enable (true) or disable (false) private subnets. Note that enabling will create 1 managed NAT gateway, with the corresponding costs."
 
   DefaultAdmins:
     Type: String
@@ -220,7 +220,7 @@ Resources:
     Properties:
       RouteTableId: !Ref PrivateSubnet2RouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId: !Ref PrivateSubnetGateway2
+      NatGatewayId: !Ref PrivateSubnetGateway1
 
   PrivateSubnet3Route:
     Condition: HasPrivateSubnet
@@ -228,7 +228,7 @@ Resources:
     Properties:
       RouteTableId: !Ref PrivateSubnet3RouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId: !Ref PrivateSubnetGateway3
+      NatGatewayId: !Ref PrivateSubnetGateway1
 
   PrivateSubnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -295,47 +295,7 @@ Resources:
         - Key: "stack"
           Value: !Ref AWS::StackName
 
-  PrivateSubnetGateway2:
-    Condition: HasPrivateSubnet
-    DependsOn: ElasticIP2
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt [ElasticIP2, AllocationId]
-      SubnetId: !Ref PublicSubnet2
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
-  PrivateSubnetGateway3:
-    Condition: HasPrivateSubnet
-    DependsOn: ElasticIP3
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt [ElasticIP3, AllocationId]
-      SubnetId: !Ref PublicSubnet3
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
   ElasticIP1:
-    Condition: HasPrivateSubnet
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
-  ElasticIP2:
-    Condition: HasPrivateSubnet
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
-  ElasticIP3:
     Condition: HasPrivateSubnet
     Type: AWS::EC2::EIP
     Properties:

--- a/cloudformation/template-v2.5.0.yaml
+++ b/cloudformation/template-v2.5.0.yaml
@@ -1,0 +1,1176 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CloudFormation stack for https://runs-on.com
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "App configuration [required]"
+        Parameters:
+          - GithubOrganization
+          - LicenseKey
+          - EmailAddress
+      - Label:
+          default: "Security and Network settings [optional]"
+        Parameters:
+          - VpcCidrBlock
+          - Private
+          - SSHCidrRange
+          - EC2InstanceCustomPolicy
+          - ServerPassword
+          - DefaultAdmins
+      - Label:
+          default: "Alert settings [optional]"
+        Parameters:
+          - AppAlarmDailyMinutes
+          - CostReportsEnabled
+          - AlertTopicSubscriptionHttpsEndpoint
+      - Label:
+          default: "Advanced app configuration [optional]"
+        Parameters:
+          - Environment
+          - RunnerDefaultDiskSize
+          - RunnerDefaultVolumeThroughput
+          - RunnerLargeDiskSize
+          - RunnerLargeVolumeThroughput
+          - ECInstanceDetailedMonitoring
+          - AppEc2QueueSize
+          - AppCPU
+          - AppMemory
+          - AppRegistry
+    ParameterLabels:
+      GithubOrganization:
+        default: "Your GitHub organization or personal name."
+
+Parameters:
+  GithubOrganization:
+    Type: String
+    Description: "For instance if your GitHub organization lives at github.com/my-org, then the value of this parameter should be: my-org"
+    MinLength: 1
+
+  LicenseKey:
+    Type: String
+    Description: "License key. Get one at https://runs-on.com/pricing."
+    MinLength: 1
+
+  EmailAddress:
+    Type: String
+    Description: Email address for cost and alert reports. You must confirm the subscription by clicking the link in the email that you will receive after creating the stack.
+    MinLength: 1
+
+  Environment:
+    Type: String
+    Default: "production"
+    Description: "Environment for the RunsOn service. You can create multiple RunsOn installations and set this parameter to different values. And then target a single installation by setting the `env=ENV_NAME` label in the `runs-on:` definition in your GitHub Actions workflow. If no label is set, the `production` environment is targeted. Most users only need the default `production` environment."
+
+  AlertTopicSubscriptionHttpsEndpoint:
+    Type: String
+    Description: HTTPS endpoint for cost and alert reports.
+    Default: ""
+
+  VpcCidrBlock:
+    Type: String
+    Description: CIDR block for the VPC. Updating this value after creation will require deleting the stack and recreating it.
+    Default: 10.1.0.0/16
+
+  SSHCidrRange:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: CIDR range for SSH access. By default, only repository collaborators with admin permission will be able to SSH into the runner instances.
+    MinLength: 1
+
+  Private:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: "Enable (true) or disable (false) private networking. If enabled, you will be able to launch runners in private subnets, and they will get a static egress IP. Note that enabling it will create 1 managed NAT gateway, with the corresponding costs. More details at https://runs-on.com/features/static-ips/."
+
+  DefaultAdmins:
+    Type: String
+    Default: ""
+    Description: Comma-separated list of GitHub usernames that will always be granted SSH access to all the runner instances (if SSH access is enabled). If blank, only repository collaborators with push permission will be able to SSH into the runner instances.
+
+  AppEc2QueueSize:
+    Type: Number
+    Default: 2
+    MinValue: 1
+    Description: "Rate limit for launching instances, per second. New AWS accounts come with a default of 2 RunInstances call/s, so only increase this if you have requested a higher limit from AWS (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html)."
+
+  AppAlarmDailyMinutes:
+    Type: Number
+    Default: "4000"
+    Description: "Trigger an alarm if the cumulative number of minutes consumed during a day is over that number."
+
+  AppCPU:
+    Type: Number
+    Default: "256"
+    Description: CPU units for RunsOn service (256 or higher). If you have many workflows, you may need to increase this (512, 1024, etc.).
+
+  AppMemory:
+    Type: Number
+    Default: "512"
+    Description: Memory in MB for RunsOn service (512 or higher). If you have many workflows, you may need to increase this (1024, 2048, etc.).
+
+  AppRegistry:
+    Type: String
+    Default: "public.ecr.aws/c5h5o9k1/runs-on/runs-on"
+    Description: "Docker image (public) registry for the RunsOn service."
+
+  RunnerDefaultDiskSize:
+    Type: Number
+    Default: 40
+    MinValue: 40
+    Description: Disk size in GB for default runners.
+
+  RunnerDefaultVolumeThroughput:
+    Type: Number
+    Default: 400
+    MinValue: 125
+    MaxValue: 1000
+    Description: Volume throughput in MiB/s for default runners (helps with faster boot times, but costs more).
+
+  RunnerLargeDiskSize:
+    Type: Number
+    Default: 80
+    MinValue: 40
+    Description: Disk size in GB for large runners.
+
+  RunnerLargeVolumeThroughput:
+    Type: Number
+    Default: 750
+    MinValue: 125
+    MaxValue: 1000
+    Description: Volume throughput in MiB/s for large runners (helps with faster boot times, but costs more).
+
+  CostReportsEnabled:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable or disable cost reports sent by email.
+
+  EC2InstanceCustomPolicy:
+    Type: String
+    Default: ""
+    Description: "Optional managed IAM Policy ARN to assign to the EC2 runner instances."
+
+  ECInstanceDetailedMonitoring:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable or disable detailed monitoring for EC2 instances (can incur additional costs).
+
+  ServerPassword:
+    Type: String
+    Default: ""
+    Description: Password for the RunsOn server (/metrics endpoint). If blank, the endpoint(s) will be disabled.
+
+Mappings:
+  App:
+    Image:
+      Tag: "v2.5.0"
+
+Conditions:
+  EmailProvided: !Not [!Equals [!Ref EmailAddress, ""]]
+  AlertTopicSubscriptionHttpsProvided:
+    !Not [!Equals [!Ref AlertTopicSubscriptionHttpsEndpoint, ""]]
+  HasPrivateSubnet: !Equals ["true", !Ref Private]
+  CustomPolicyProvided: !Not [!Equals [!Ref EC2InstanceCustomPolicy, ""]]
+  ECInstanceDetailedMonitoringEnabled: !Equals ["true", !Ref ECInstanceDetailedMonitoring]
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidrBlock
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-VPC
+
+  PrivateSubnet1RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet1RouteTable
+
+  PrivateSubnet2RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2RouteTable
+
+  PrivateSubnet3RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3RouteTable
+
+  PrivateSubnet1Route:
+    Condition: HasPrivateSubnet
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateSubnet1RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref PrivateSubnetGateway1
+
+  PrivateSubnet2Route:
+    Condition: HasPrivateSubnet
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateSubnet2RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref PrivateSubnetGateway1
+
+  PrivateSubnet3Route:
+    Condition: HasPrivateSubnet
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateSubnet3RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref PrivateSubnetGateway1
+
+  PrivateSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateSubnet1RouteTable
+
+  PrivateSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateSubnet2RouteTable
+
+  PrivateSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateSubnet3RouteTable
+
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: !Select [8, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  PrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: !Select [9, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2
+
+  PrivateSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      CidrBlock: !Select [10, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3
+
+  PrivateSubnetGateway1:
+    Condition: HasPrivateSubnet
+    DependsOn: ElasticIP1
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt [ElasticIP1, AllocationId]
+      SubnetId: !Ref PublicSubnet1
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnetGateway1
+
+  ElasticIP1:
+    Condition: HasPrivateSubnet
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-ElasticIP1
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [0, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet1
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [1, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet2
+
+  PublicSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: VPC
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      # Dynamically generate a CIDR block with non-overlapping IP ranges for each possible AZ in the region
+      # https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
+      CidrBlock: !Select [2, !Cidr [!GetAtt [VPC, CidrBlock], 16, 12]]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet3
+
+  S3VpcEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref VPC
+      ServiceName:
+        Fn::Sub: "com.amazonaws.${AWS::Region}.s3"
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PublicRouteTable
+        - !Ref PrivateSubnet1RouteTable
+        - !Ref PrivateSubnet2RouteTable
+        - !Ref PrivateSubnet3RouteTable
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-InternetGateway
+
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicRouteTable
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  SubnetRouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref PublicRouteTable
+
+  SubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  SubnetRouteTableAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html
+  EC2FleetLaunchTemplateLinuxDefault:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        # Can't set CreditSpecification here, because standard instances would raise e.g.:
+        #   InstanceCreditSpecification.NotSupported - The c7a.large instance type does not support T2 Unlimited.
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+          InstanceMetadataTags: enabled
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: !Ref RunnerDefaultDiskSize
+              VolumeType: gp3
+              Throughput: !Ref RunnerDefaultVolumeThroughput
+              Iops: 3000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
+        Monitoring:
+          !If
+            - ECInstanceDetailedMonitoringEnabled
+            - Enabled: true
+            - Ref: AWS::NoValue
+        UserData:
+          Fn::Base64: !Sub
+            - |
+              #!/bin/bash -e
+              _the_end() {
+                echo "user-data: Going to shut down in a few seconds..." && sleep 45s && shutdown -h now
+              } ; trap _the_end EXIT INT TERM
+              export RUNS_ON_BOOSTRAP_PATH="${S3Bucket}.s3.${AWS::Region}.amazonaws.com/agents/${AppVersion}"
+              export RUNS_ON_LOG_GROUP_NAME="${EC2InstanceLogGroup}"
+              b=$(mktemp) ; time curl --connect-time 3 --max-time 10 --retry 5 -s "https://$RUNS_ON_BOOSTRAP_PATH/bootstrap.sh" -o $b ; bash -ex $b
+            - AppVersion: !FindInMap [App, Image, Tag]
+
+  EC2FleetLaunchTemplateLinuxLarge:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+          InstanceMetadataTags: enabled
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: !Ref RunnerLargeDiskSize
+              VolumeType: gp3
+              Throughput: !Ref RunnerLargeVolumeThroughput
+              Iops: 4000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
+        Monitoring:
+          !If
+            - ECInstanceDetailedMonitoringEnabled
+            - Enabled: true
+            - Ref: AWS::NoValue
+        UserData:
+          Fn::Base64: !Sub
+            - |
+              #!/bin/bash -e
+              _the_end() {
+                echo "user-data: Going to shut down in a few seconds..." && sleep 45s && shutdown -h now
+              } ; trap _the_end EXIT INT TERM
+              export RUNS_ON_BOOSTRAP_PATH="${S3Bucket}.s3.${AWS::Region}.amazonaws.com/agents/${AppVersion}"
+              export RUNS_ON_LOG_GROUP_NAME="${EC2InstanceLogGroup}"
+              b=$(mktemp) ; time curl --connect-time 3 --max-time 10 --retry 5 -s "https://$RUNS_ON_BOOSTRAP_PATH/bootstrap.sh" -o $b ; bash -ex $b
+            - AppVersion: !FindInMap [App, Image, Tag]
+
+  EC2FleetLaunchTemplateWindowsDefault:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        # Can't set CreditSpecification here, because standard instances would raise e.g.:
+        #   InstanceCreditSpecification.NotSupported - The c7a.large instance type does not support T2 Unlimited.
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+          InstanceMetadataTags: enabled
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: !Ref RunnerDefaultDiskSize
+              VolumeType: gp3
+              Throughput: !Ref RunnerDefaultVolumeThroughput
+              Iops: 3000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
+        Monitoring:
+          !If
+            - ECInstanceDetailedMonitoringEnabled
+            - Enabled: true
+            - Ref: AWS::NoValue
+        UserData:
+          Fn::Base64: !Sub
+            - |
+              <powershell>
+              try {
+                $env:RUNS_ON_BOOSTRAP_PATH = "${S3Bucket}.s3.${AWS::Region}.amazonaws.com/agents/${AppVersion}"
+                $env:RUNS_ON_LOG_GROUP_NAME = "${EC2InstanceLogGroup}"
+                $b = [System.IO.Path]::ChangeExtension((New-TemporaryFile).FullName, ".ps1")
+                Write-Host "Downloading bootstrap.ps1 to $b"
+                Invoke-WebRequest -Uri "https://$env:RUNS_ON_BOOSTRAP_PATH/bootstrap.ps1" -OutFile $b -UseBasicParsing
+                Write-Host "Running $b"
+                powershell -File $b
+              } finally {
+                Write-Output "user-data: Going to shut down in a few seconds..."
+                Start-Sleep -Seconds 45
+                Stop-Computer -Force
+              }
+              </powershell>
+            - AppVersion: !FindInMap [App, Image, Tag]
+
+  EC2FleetLaunchTemplateWindowsLarge:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        EbsOptimized: "true"
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+          InstanceMetadataTags: enabled
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: !Ref RunnerLargeDiskSize
+              VolumeType: gp3
+              Throughput: !Ref RunnerLargeVolumeThroughput
+              Iops: 4000
+              DeleteOnTermination: true
+        InstanceInitiatedShutdownBehavior: "terminate"
+        Monitoring:
+          !If
+            - ECInstanceDetailedMonitoringEnabled
+            - Enabled: true
+            - Ref: AWS::NoValue
+        UserData:
+          Fn::Base64: !Sub
+            - |
+              <powershell>
+              try {
+                $env:RUNS_ON_BOOSTRAP_PATH = "${S3Bucket}.s3.${AWS::Region}.amazonaws.com/agents/${AppVersion}"
+                $env:RUNS_ON_LOG_GROUP_NAME = "${EC2InstanceLogGroup}"
+                $b = [System.IO.Path]::ChangeExtension((New-TemporaryFile).FullName, ".ps1")
+                Write-Host "Downloading bootstrap.ps1 to $b"
+                Invoke-WebRequest -Uri "https://$env:RUNS_ON_BOOSTRAP_PATH/bootstrap.ps1" -OutFile $b -UseBasicParsing
+                Write-Host "Running $b"
+                powershell -File $b
+              } finally {
+                Write-Output "user-data: Going to shut down in a few seconds..."
+                Start-Sleep -Seconds 45
+                Stop-Computer -Force
+              }
+              </powershell>
+            - AppVersion: !FindInMap [App, Image, Tag]
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for SSH access
+      VpcId:
+        Ref: VPC
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::Sub: "${SSHCidrRange}"
+          FromPort: 22
+          ToPort: 22
+          IpProtocol: tcp
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: RetainExceptOnCreate
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: "runs-on/purpose"
+          Value: "config"
+
+  S3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowReadForAgentBinariesFromVpcEndpoint
+            Effect: Allow
+            Principal: "*"
+            Action: "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${S3Bucket}/agents/*"
+            Condition:
+              StringEquals:
+                aws:SourceVpce: !Ref S3VpcEndpoint
+
+  S3BucketCache:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: RetainExceptOnCreate
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireRunnerConfig
+            Prefix: runners/
+            Status: Enabled
+            ExpirationInDays: 1
+          - Id: ExpireCache
+            Prefix: cache/
+            Status: Enabled
+            ExpirationInDays: 10
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+        - Key: "runs-on/purpose"
+          Value: "cache"
+
+  EC2InstanceLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 7
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  EC2InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy], []]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: TagInstance
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:CreateTags
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "aws:ARN": "${ec2:SourceInstanceARN}"
+        - PolicyName: SendLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:PutLogEvents"
+                  - "logs:PutRetentionPolicy"
+                  - "logs:DescribeLogStreams"
+                  - "logs:DescribeLogGroups"
+                  - "logs:CreateLogStream"
+                  - "logs:CreateLogGroup"
+                Resource: 
+                - !Sub "${EC2InstanceLogGroup.Arn}"
+                - !Sub "${EC2InstanceLogGroup.Arn}:*"
+        - PolicyName: SendMetrics
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    cloudwatch:namespace: "RunsOn/Runners"
+        - PolicyName: EC2AccessS3BucketPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                  - s3:ListBucket
+                  - s3:GetBucketLocation
+                  - s3:ListBucketMultipartUploads
+                  - s3:ListMultipartUploadParts
+                Resource:
+                  - !Sub "arn:aws:s3:::${S3BucketCache}"
+                  - !Sub "arn:aws:s3:::${S3BucketCache}/cache/*"
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Join
+                    - ""
+                    - [
+                        !Sub "arn:aws:s3:::${S3BucketCache}/runners/",
+                        "${aws:userid}/*",
+                      ]
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  EC2InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref EC2InstanceRole
+
+  RunsOnServiceAutoScalingConfiguration:
+    Type: AWS::AppRunner::AutoScalingConfiguration
+    Properties:
+      MaxConcurrency: 100
+      MaxSize: 25
+      MinSize: 1
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  RunsOnService:
+    Type: AWS::AppRunner::Service
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      InstanceConfiguration:
+        Cpu: !Ref AppCPU
+        Memory: !Ref AppMemory
+        InstanceRoleArn: !GetAtt RunsOnServiceRole.Arn
+      NetworkConfiguration:
+        EgressConfiguration:
+          EgressType: DEFAULT
+        IngressConfiguration:
+          IsPubliclyAccessible: true
+        IpAddressType: IPV4
+      HealthCheckConfiguration:
+        Path: /ping
+        Protocol: HTTP
+        HealthyThreshold: 1
+        UnhealthyThreshold: 10
+        Interval: 3
+      AutoScalingConfigurationArn: !Ref RunsOnServiceAutoScalingConfiguration
+      SourceConfiguration:
+        ImageRepository:
+          ImageConfiguration:
+            Port: 8080
+            RuntimeEnvironmentVariables:
+              - Name: RUNS_ON_ENV
+                Value: !Ref Environment
+              - Name: RUNS_ON_STACK_NAME
+                Value: !Ref AWS::StackName
+              - Name: RUNS_ON_ORG
+                Value: !Ref GithubOrganization
+              - Name: RUNS_ON_APP_VERSION
+                Value: !FindInMap [App, Image, Tag]
+              - Name: RUNS_ON_LICENSE_KEY
+                Value: !Ref LicenseKey
+              - Name: RUNS_ON_BUCKET_CONFIG
+                Value: !Ref S3Bucket
+              - Name: RUNS_ON_BUCKET_CACHE
+                Value: !Ref S3BucketCache
+              - Name: RUNS_ON_SECURITY_GROUP_ID
+                Value: !Ref SecurityGroup
+              - Name: RUNS_ON_INSTANCE_PROFILE_ARN
+                Value: !GetAtt EC2InstanceProfile.Arn
+              - Name: RUNS_ON_INSTANCE_ROLE_NAME
+                Value: !Ref EC2InstanceRole
+              - Name: RUNS_ON_TOPIC_ARN
+                Value: !Ref AlertTopic
+              - Name: RUNS_ON_REGION
+                Value: !Ref AWS::Region
+              - Name: RUNS_ON_APP_EC2_QUEUE_SIZE
+                Value: !Ref AppEc2QueueSize
+              - Name: RUNS_ON_PUBLIC_SUBNET1
+                Value: !Ref PublicSubnet1
+              - Name: RUNS_ON_PUBLIC_SUBNET2
+                Value: !Ref PublicSubnet2
+              - Name: RUNS_ON_PUBLIC_SUBNET3
+                Value: !Ref PublicSubnet3
+              - Name: RUNS_ON_PRIVATE_SUBNET1
+                Value: !Ref PrivateSubnet1
+              - Name: RUNS_ON_PRIVATE_SUBNET2
+                Value: !Ref PrivateSubnet2
+              - Name: RUNS_ON_PRIVATE_SUBNET3
+                Value: !Ref PrivateSubnet3
+              - Name: RUNS_ON_PRIVATE
+                Value: !Ref Private
+              - Name: RUNS_ON_DEFAULT_ADMINS
+                Value: !Ref DefaultAdmins
+              - Name: RUNS_ON_LAUNCH_TEMPLATE_LINUX_DEFAULT
+                Value: !Ref EC2FleetLaunchTemplateLinuxDefault
+              - Name: RUNS_ON_LAUNCH_TEMPLATE_LINUX_LARGE
+                Value: !Ref EC2FleetLaunchTemplateLinuxLarge
+              - Name: RUNS_ON_LAUNCH_TEMPLATE_WINDOWS_DEFAULT
+                Value: !Ref EC2FleetLaunchTemplateWindowsDefault
+              - Name: RUNS_ON_LAUNCH_TEMPLATE_WINDOWS_LARGE
+                Value: !Ref EC2FleetLaunchTemplateWindowsLarge
+              - Name: RUNS_ON_RUNNER_DEFAULT_DISK_SIZE
+                Value: !Ref RunnerDefaultDiskSize
+              - Name: RUNS_ON_RUNNER_LARGE_DISK_SIZE
+                Value: !Ref RunnerLargeDiskSize
+              - Name: RUNS_ON_QUEUE
+                Value: !Ref RunsOnQueue
+              - Name: RUNS_ON_COST_REPORTS_ENABLED
+                Value: !Ref CostReportsEnabled
+              - Name: RUNS_ON_SERVER_PASSWORD
+                Value: !Ref ServerPassword
+          ImageIdentifier: !Sub
+            - "${AppRegistry}:${AppVersion}"
+            - AppVersion: !FindInMap [App, Image, Tag]
+          ImageRepositoryType: ECR_PUBLIC
+
+  RunsOnServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - tasks.apprunner.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: AppRunnerEC2Permissions
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeImages
+                  - ec2:DescribeInstances
+                  - ce:GetCostAndUsage
+                  - ce:UpdateCostAllocationTagsStatus
+                  - cloudwatch:PutMetricData
+                  - cloudwatch:GetMetricData
+                  - cloudwatch:DescribeAlarms
+                  - cloudtrail:LookupEvents
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                Resource: !Ref AWS::StackId
+              - Effect: Allow
+                Action:
+                  - ec2:CreateFleet
+                  - ec2:DeleteFleet
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ec2:CreateTags
+                  - ec2:RunInstances
+                Resource:
+                  - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
+                  - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                  - iam:GetRole
+                Resource: !GetAtt EC2InstanceRole.Arn
+              - Effect: Allow
+                Action:
+                  - ec2:TerminateInstances
+                Resource: "arn:aws:ec2:*:*:instance/*"
+                Condition:
+                  StringEquals:
+                    "aws:ResourceTag/stack": !Ref AWS::StackName
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource:
+                  - Fn::Sub: arn:aws:s3:::${S3Bucket}
+                  - Fn::Sub: arn:aws:s3:::${S3Bucket}/*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource:
+                  - Fn::Sub: arn:aws:s3:::${S3BucketCache}
+                  - Fn::Sub: arn:aws:s3:::${S3BucketCache}/runners/*
+                  - Fn::Sub: arn:aws:s3:::${S3BucketCache}/agents/*
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref AlertTopic
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !GetAtt RunsOnQueue.Arn
+
+  MinutesPerDayAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub "RunsOn daily usage exceeds ${AppAlarmDailyMinutes} minutes"
+      Namespace: RunsOn
+      MetricName: minutesNoDimension
+      Statistic: Sum
+      Period: 86400 # 24h
+      EvaluationPeriods: 1
+      Threshold: !Ref AppAlarmDailyMinutes
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref AlertTopic
+      OKActions:
+        - !Ref AlertTopic
+
+  RunsOnQueueDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      FifoQueue: true
+      MessageRetentionPeriod: 259200 # 3 days
+
+  RunsOnQueueDeadLetterPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref RunsOnQueueDeadLetter
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: "sqs:SendMessage"
+            Resource: !GetAtt RunsOnQueueDeadLetter.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref RunsOnQueue
+
+  RunsOnQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      FifoQueue: true
+      ContentBasedDeduplication: true
+      MessageRetentionPeriod: 86400 # 24h
+      ReceiveMessageWaitTimeSeconds: 10
+      VisibilityTimeout: 120 # AWS recommends 6 times the max processing time
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt RunsOnQueueDeadLetter.Arn
+        maxReceiveCount: 5
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+
+  AlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: "stack"
+          Value: !Ref AWS::StackName
+      DisplayName: RunsOn Alerts
+
+  AlertTopicSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: email
+      TopicArn: !Ref AlertTopic
+      Endpoint: !If [EmailProvided, !Ref EmailAddress, ""]
+
+  AlertTopicSubscriptionHttps:
+    Condition: AlertTopicSubscriptionHttpsProvided
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: https
+      TopicArn: !Ref AlertTopic
+      Endpoint: !Ref AlertTopicSubscriptionHttpsEndpoint
+
+Outputs:
+  RunsOnEntryPoint:
+    Description: Entrypoint for the RunsOn service
+    Value: !GetAtt RunsOnService.ServiceUrl
+  RunsOnService:
+    Description: Link to the AppRunner service in AWS console
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/apprunner/home?region=${AWS::Region}#/services/dashboard?service_arn=${RunsOnService}"
+  RunsOnOrg:
+    Description: GitHub organization or personal account
+    Value: !Ref GithubOrganization
+  RunsOnLicenseKey:
+    Description: License key
+    Value: !Ref LicenseKey
+  RunsOnRegion:
+    Description: AWS region
+    Value: !Ref AWS::Region
+  RunsOnVPCId:
+    Description: VPC ID
+    Value: !Ref VPC
+    Export:
+      Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnPublicRouteTableId:
+    Description: Public Route Table ID
+    Value: !Ref PublicRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PublicRouteTableId"
+  RunsOnPrivateRouteTable1Id:
+    Description: Private Route Table 1 ID
+    Value: !Ref PrivateSubnet1RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable1Id"
+  RunsOnPrivateRouteTable2Id:
+    Description: Private Route Table 2 ID
+    Value: !Ref PrivateSubnet2RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable2Id"
+  RunsOnPrivateRouteTable3Id:
+    Description: Private Route Table 3 ID
+    Value: !Ref PrivateSubnet3RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable3Id"
+  RunsOnEgressStaticIP:
+    Description: Static IP for egress traffic (if configured)
+    Value: !If
+      - HasPrivateSubnet
+      - !Ref ElasticIP1
+      - "-"
+  RunsOnPublicSubnet1:
+    Description: Public subnet 1
+    Value: !Ref PublicSubnet1
+  RunsOnPublicSubnet2:
+    Description: Public subnet 2
+    Value: !Ref PublicSubnet2
+  RunsOnPublicSubnet3:
+    Description: Public subnet 3
+    Value: !Ref PublicSubnet3
+  RunsOnPrivateSubnet1:
+    Description: Private subnet 1
+    Value: !Ref PrivateSubnet1
+  RunsOnPrivateSubnet2:
+    Description: Private subnet 2
+    Value: !Ref PrivateSubnet2
+  RunsOnPrivateSubnet3:
+    Description: Private subnet 3
+    Value: !Ref PrivateSubnet3
+  RunsOnPrivate:
+    Description: Private subnets enabled
+    Value: !Ref Private
+  RunsOnRunnerDefaultDiskSize:
+    Description: Default disk size for runners
+    Value: !Ref RunnerDefaultDiskSize
+  RunsOnRunnerLargeDiskSize:
+    Description: Large disk size for runners
+    Value: !Ref RunnerLargeDiskSize
+  RunsOnInstanceProfileArn:
+    Description: Runner instance profile ARN
+    Value: !GetAtt EC2InstanceProfile.Arn
+  RunsOnInstanceProfileName:
+    Description: Runner instance profile Name
+    Value: !Ref EC2InstanceProfile
+  RunsOnInstanceRoleName:
+    Description: Runner instance role Name
+    Value: !Ref EC2InstanceRole
+  RunsOnSecurityGroupId:
+    Description: Security group for runners
+    Value: !Ref SecurityGroup
+  RunsOnBucketConfig:
+    Description: S3 bucket for storing configuration
+    Value: !Ref S3Bucket
+  RunsOnBucketCache:
+    Description: S3 bucket for storing cache artefacts
+    Value: !Ref S3BucketCache
+  RunsOnTopicArn:
+    Description: SNS Topic where email alerts and reports are sent
+    Value: !Ref AlertTopic
+  RunsOnDefaultAdmins:
+    Description: Default GitHub usernames with SSH access to the runners
+    Value: !Ref DefaultAdmins
+  RunsOnLaunchTemplateLinuxDefault:
+    Description: Default Linux launch template for the RunsOn service
+    Value: !Ref EC2FleetLaunchTemplateLinuxDefault
+  RunsOnLaunchTemplateLinuxLarge:
+    Description: Large Linux launch template for the RunsOn service
+    Value: !Ref EC2FleetLaunchTemplateLinuxLarge
+  RunsOnLaunchTemplateWindowsDefault:
+    Description: Default Windows launch template for the RunsOn service
+    Value: !Ref EC2FleetLaunchTemplateWindowsDefault
+  RunsOnLaunchTemplateWindowsLarge:
+    Description: Large Windows launch template for the RunsOn service
+    Value: !Ref EC2FleetLaunchTemplateWindowsLarge
+  RunsOnAppVersion:
+    Description: Version of the RunsOn service
+    Value: !FindInMap [App, Image, Tag]
+  RunsOnStackName:
+    Description: Name of the stack
+    Value: !Ref AWS::StackName
+  RunsOnAppEc2QueueSize:
+    Description: Size of the EC2 queue
+    Value: !Ref AppEc2QueueSize
+  RunsOnQueue:
+    Description: SQS queue for the RunsOn service
+    Value: !Ref RunsOnQueue
+  RunsOnCostReportsEnabled:
+    Description: Enable or disable cost reports sent by email
+    Value: !Ref CostReportsEnabled
+  RunsOnServerPassword:
+    Description: Password for the RunsOn server
+    Value: !Ref ServerPassword

--- a/cloudformation/template-v2.5.0.yaml
+++ b/cloudformation/template-v2.5.0.yaml
@@ -29,6 +29,7 @@ Metadata:
           default: "Advanced app configuration [optional]"
         Parameters:
           - Environment
+          - RunnerCustomTags
           - RunnerDefaultDiskSize
           - RunnerDefaultVolumeThroughput
           - RunnerLargeDiskSize
@@ -143,6 +144,11 @@ Parameters:
     MinValue: 125
     MaxValue: 1000
     Description: Volume throughput in MiB/s for large runners (helps with faster boot times, but costs more).
+
+  RunnerCustomTags:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: "Optional custom tags for the runner instances (e.g. 'key1=value1,key2=value2'). Tag keys can only use letters (a-z, A-Z), numbers (0-9), and the following characters: + - = . , _ : @ (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions)"
 
   CostReportsEnabled:
     Type: String
@@ -830,6 +836,8 @@ Resources:
                 Value: !FindInMap [App, Image, Tag]
               - Name: RUNS_ON_LICENSE_KEY
                 Value: !Ref LicenseKey
+              - Name: RUNS_ON_RUNNER_CUSTOM_TAGS
+                Value: !Join [",", !Ref RunnerCustomTags]
               - Name: RUNS_ON_BUCKET_CONFIG
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_BUCKET_CACHE
@@ -1067,6 +1075,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnVpcCidrBlock:
+    Description: VPC CIDR block
+    Value: !Ref VpcCidrBlock
+    Export:
+      Name: !Sub "${AWS::StackName}-VpcCidrBlock"
   RunsOnPublicRouteTableId:
     Description: Public Route Table ID
     Value: !Ref PublicRouteTable
@@ -1120,6 +1133,9 @@ Outputs:
   RunsOnRunnerLargeDiskSize:
     Description: Large disk size for runners
     Value: !Ref RunnerLargeDiskSize
+  RunsOnRunnerCustomTags:
+    Description: Custom tags for runners
+    Value: !Join [",", !Ref RunnerCustomTags]
   RunsOnInstanceProfileArn:
     Description: Runner instance profile ARN
     Value: !GetAtt EC2InstanceProfile.Arn

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -28,6 +28,7 @@ Metadata:
       - Label:
           default: "Advanced app configuration [optional]"
         Parameters:
+          - Environment
           - RunnerDefaultDiskSize
           - RunnerDefaultVolumeThroughput
           - RunnerLargeDiskSize
@@ -56,6 +57,11 @@ Parameters:
     Type: String
     Description: Email address for cost and alert reports. You must confirm the subscription by clicking the link in the email that you will receive after creating the stack.
     MinLength: 1
+
+  Environment:
+    Type: String
+    Default: "production"
+    Description: "Environment for the RunsOn service. You can create multiple RunsOn installations and set this parameter to different values. And then target a single installation by setting the `env=ENV_NAME` label in the `runs-on:` definition in your GitHub Actions workflow. If no label is set, the `production` environment is targeted. Most users only need the default `production` environment."
 
   AlertTopicSubscriptionHttpsEndpoint:
     Type: String
@@ -814,6 +820,8 @@ Resources:
           ImageConfiguration:
             Port: 8080
             RuntimeEnvironmentVariables:
+              - Name: RUNS_ON_ENV
+                Value: !Ref Environment
               - Name: RUNS_ON_STACK_NAME
                 Value: !Ref AWS::StackName
               - Name: RUNS_ON_ORG

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -11,13 +11,14 @@ Metadata:
           - LicenseKey
           - EmailAddress
       - Label:
-          default: "Security settings [optional]"
+          default: "Security and Network settings [optional]"
         Parameters:
-          - ServerPassword
+          - VpcCidrBlock
           - Private
-          - DefaultAdmins
           - SSHCidrRange
           - EC2InstanceCustomPolicy
+          - ServerPassword
+          - DefaultAdmins
       - Label:
           default: "Alert settings [optional]"
         Parameters:
@@ -53,7 +54,7 @@ Parameters:
 
   EmailAddress:
     Type: String
-    Description: Email address for cost and alert reports.
+    Description: Email address for cost and alert reports. You must confirm the subscription by clicking the link in the email that you will receive after creating the stack.
     MinLength: 1
 
   AlertTopicSubscriptionHttpsEndpoint:
@@ -61,10 +62,15 @@ Parameters:
     Description: HTTPS endpoint for cost and alert reports.
     Default: ""
 
+  VpcCidrBlock:
+    Type: String
+    Description: CIDR block for the VPC. Updating this value after creation will require deleting the stack and recreating it.
+    Default: 10.1.0.0/16
+
   SSHCidrRange:
     Type: String
     Default: 0.0.0.0/0
-    Description: CIDR range for SSH access (mainly useful when Private=false). By default, only repository collaborators with admin permission will be able to SSH into the runner instances.
+    Description: CIDR range for SSH access. By default, only repository collaborators with admin permission will be able to SSH into the runner instances.
     MinLength: 1
 
   Private:
@@ -73,7 +79,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: "Enable (true) or disable (false) private subnets. Note that enabling will create 3 managed NAT gateways, with the corresponding costs."
+    Description: "Enable (true) or disable (false) private networking. If enabled, you will be able to launch runners in private subnets, and they will get a static egress IP. Note that enabling it will create 1 managed NAT gateway, with the corresponding costs. More details at https://runs-on.com/features/static-ips/."
 
   DefaultAdmins:
     Type: String
@@ -161,7 +167,7 @@ Parameters:
 Mappings:
   App:
     Image:
-      Tag: "v2.4.0"
+      Tag: "v2.5.0"
 
 Conditions:
   EmailProvided: !Not [!Equals [!Ref EmailAddress, ""]]
@@ -175,12 +181,14 @@ Resources:
   VPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 10.1.0.0/16
+      CidrBlock: !Ref VpcCidrBlock
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-VPC
 
   PrivateSubnet1RouteTable:
     Type: AWS::EC2::RouteTable
@@ -189,6 +197,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet1RouteTable
 
   PrivateSubnet2RouteTable:
     Type: AWS::EC2::RouteTable
@@ -197,6 +207,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2RouteTable
 
   PrivateSubnet3RouteTable:
     Type: AWS::EC2::RouteTable
@@ -205,6 +217,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3RouteTable
 
   PrivateSubnet1Route:
     Condition: HasPrivateSubnet
@@ -220,7 +234,7 @@ Resources:
     Properties:
       RouteTableId: !Ref PrivateSubnet2RouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId: !Ref PrivateSubnetGateway2
+      NatGatewayId: !Ref PrivateSubnetGateway1
 
   PrivateSubnet3Route:
     Condition: HasPrivateSubnet
@@ -228,7 +242,7 @@ Resources:
     Properties:
       RouteTableId: !Ref PrivateSubnet3RouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId: !Ref PrivateSubnetGateway3
+      NatGatewayId: !Ref PrivateSubnetGateway1
 
   PrivateSubnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -271,6 +285,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet2
 
   PrivateSubnet3:
     Type: AWS::EC2::Subnet
@@ -283,6 +299,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnet3
 
   PrivateSubnetGateway1:
     Condition: HasPrivateSubnet
@@ -294,28 +312,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
-
-  PrivateSubnetGateway2:
-    Condition: HasPrivateSubnet
-    DependsOn: ElasticIP2
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt [ElasticIP2, AllocationId]
-      SubnetId: !Ref PublicSubnet2
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
-  PrivateSubnetGateway3:
-    Condition: HasPrivateSubnet
-    DependsOn: ElasticIP3
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt [ElasticIP3, AllocationId]
-      SubnetId: !Ref PublicSubnet3
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PrivateSubnetGateway1
 
   ElasticIP1:
     Condition: HasPrivateSubnet
@@ -325,24 +323,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
-
-  ElasticIP2:
-    Condition: HasPrivateSubnet
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
-
-  ElasticIP3:
-    Condition: HasPrivateSubnet
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: "stack"
-          Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-ElasticIP1
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
@@ -357,6 +339,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet1
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
@@ -371,6 +355,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet2
 
   PublicSubnet3:
     Type: AWS::EC2::Subnet
@@ -385,6 +371,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicSubnet3
 
   S3VpcEndpoint:
     Type: AWS::EC2::VPCEndpoint
@@ -405,6 +393,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-InternetGateway
 
   AttachGateway:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -419,6 +409,8 @@ Resources:
       Tags:
         - Key: "stack"
           Value: !Ref AWS::StackName
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-PublicRouteTable
 
   PublicRoute:
     Type: AWS::EC2::Route
@@ -702,7 +694,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:
-        # !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy, "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"], ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]]
         !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy], []]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -1063,6 +1054,37 @@ Outputs:
   RunsOnRegion:
     Description: AWS region
     Value: !Ref AWS::Region
+  RunsOnVPCId:
+    Description: VPC ID
+    Value: !Ref VPC
+    Export:
+      Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnPublicRouteTableId:
+    Description: Public Route Table ID
+    Value: !Ref PublicRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PublicRouteTableId"
+  RunsOnPrivateRouteTable1Id:
+    Description: Private Route Table 1 ID
+    Value: !Ref PrivateSubnet1RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable1Id"
+  RunsOnPrivateRouteTable2Id:
+    Description: Private Route Table 2 ID
+    Value: !Ref PrivateSubnet2RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable2Id"
+  RunsOnPrivateRouteTable3Id:
+    Description: Private Route Table 3 ID
+    Value: !Ref PrivateSubnet3RouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-PrivateRouteTable3Id"
+  RunsOnEgressStaticIP:
+    Description: Static IP for egress traffic (if configured)
+    Value: !If
+      - HasPrivateSubnet
+      - !Ref ElasticIP1
+      - "-"
   RunsOnPublicSubnet1:
     Description: Public subnet 1
     Value: !Ref PublicSubnet1

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -29,6 +29,7 @@ Metadata:
           default: "Advanced app configuration [optional]"
         Parameters:
           - Environment
+          - RunnerCustomTags
           - RunnerDefaultDiskSize
           - RunnerDefaultVolumeThroughput
           - RunnerLargeDiskSize
@@ -143,6 +144,11 @@ Parameters:
     MinValue: 125
     MaxValue: 1000
     Description: Volume throughput in MiB/s for large runners (helps with faster boot times, but costs more).
+
+  RunnerCustomTags:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: "Optional custom tags for the runner instances (e.g. 'key1=value1,key2=value2'). Tag keys can only use letters (a-z, A-Z), numbers (0-9), and the following characters: + - = . , _ : @ (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions)"
 
   CostReportsEnabled:
     Type: String
@@ -830,6 +836,8 @@ Resources:
                 Value: !FindInMap [App, Image, Tag]
               - Name: RUNS_ON_LICENSE_KEY
                 Value: !Ref LicenseKey
+              - Name: RUNS_ON_RUNNER_CUSTOM_TAGS
+                Value: !Join [",", !Ref RunnerCustomTags]
               - Name: RUNS_ON_BUCKET_CONFIG
                 Value: !Ref S3Bucket
               - Name: RUNS_ON_BUCKET_CACHE
@@ -1067,6 +1075,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub "${AWS::StackName}-VPCId"
+  RunsOnVpcCidrBlock:
+    Description: VPC CIDR block
+    Value: !Ref VpcCidrBlock
+    Export:
+      Name: !Sub "${AWS::StackName}-VpcCidrBlock"
   RunsOnPublicRouteTableId:
     Description: Public Route Table ID
     Value: !Ref PublicRouteTable
@@ -1120,6 +1133,9 @@ Outputs:
   RunsOnRunnerLargeDiskSize:
     Description: Large disk size for runners
     Value: !Ref RunnerLargeDiskSize
+  RunsOnRunnerCustomTags:
+    Description: Custom tags for runners
+    Value: !Join [",", !Ref RunnerCustomTags]
   RunsOnInstanceProfileArn:
     Description: Runner instance profile ARN
     Value: !GetAtt EC2InstanceProfile.Arn

--- a/cloudformation/vpc-peering.yaml
+++ b/cloudformation/vpc-peering.yaml
@@ -1,0 +1,82 @@
+# This template allows you to create a VPC Peering connection between one of your existing VPC and RunsOn's VPC.
+# It can be reused multiple times to create multiple VPC Peering connections.
+#
+# Note that you will still need to add a corresponding route back to the RunsOn VPC, in the destination VPC's route table(s) to complete the peering setup.
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "VPC Peering Connection for RunsOn (https://runs-on.com)"
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "VPC Peering Connection configuration [required]"
+        Parameters:
+          - RunsOnStackName
+          - DestinationVpcId
+          - DestinationVpcCidr
+
+Parameters:
+  RunsOnStackName:
+    Type: String
+    Description: "Name of the CloudFormation stack for RunsOn."
+    Default: "runs-on"
+
+  DestinationVpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: "ID of the destination VPC to peer with."
+
+  DestinationVpcCidr:
+    Type: String
+    Description: "CIDR block of the destination VPC."
+    Default: "10.0.0.0/16"
+
+Resources:
+  VPCPeeringConnection:
+    Type: AWS::EC2::VPCPeeringConnection
+    Properties:
+      VpcId: 
+        Fn::ImportValue: !Sub "${RunsOnStackName}-VPCId"
+      PeerVpcId: !Ref DestinationVpcId
+      Tags:
+        - Key: Name
+          Value: !Sub ${RunsOnStackName}-VPCPeering
+        - Key: stack
+          Value: !Ref AWS::StackName
+
+  PublicRouteTablePeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: 
+        Fn::ImportValue: !Sub "${RunsOnStackName}-PublicRouteTableId"
+      DestinationCidrBlock: !Ref DestinationVpcCidr
+      VpcPeeringConnectionId: !Ref VPCPeeringConnection
+
+  PrivateRouteTable1PeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: 
+        Fn::ImportValue: !Sub "${RunsOnStackName}-PrivateRouteTable1Id"
+      DestinationCidrBlock: !Ref DestinationVpcCidr
+      VpcPeeringConnectionId: !Ref VPCPeeringConnection
+
+  PrivateRouteTable2PeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: 
+        Fn::ImportValue: !Sub "${RunsOnStackName}-PrivateRouteTable2Id"
+      DestinationCidrBlock: !Ref DestinationVpcCidr
+      VpcPeeringConnectionId: !Ref VPCPeeringConnection
+
+  PrivateRouteTable3PeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: 
+        Fn::ImportValue: !Sub "${RunsOnStackName}-PrivateRouteTable3Id"
+      DestinationCidrBlock: !Ref DestinationVpcCidr
+      VpcPeeringConnectionId: !Ref VPCPeeringConnection
+
+Outputs:
+  VPCPeeringConnectionId:
+    Description: VPC Peering Connection ID
+    Value: !Ref VPCPeeringConnection

--- a/cloudformation/vpc-peering.yaml
+++ b/cloudformation/vpc-peering.yaml
@@ -77,6 +77,6 @@ Resources:
       VpcPeeringConnectionId: !Ref VPCPeeringConnection
 
 Outputs:
-  VPCPeeringConnectionId:
+  RunsOnVpcPeeringConnectionId:
     Description: VPC Peering Connection ID
     Value: !Ref VPCPeeringConnection


### PR DESCRIPTION
Summary: Allow to assign an environment name to each RunsOn stack. Allow to specify VPC CIDR block and export outputs to facilitate VPC peering connections. Allow to set custom tags on instances.

## Potentially breaking changes

If you have set the `Private` parameter to `true` in the CloudFormation template, the behaviour has changed:

- The stack will now create only 1 managed NAT gateway (instead of 3) when enabling `Private` mode, to save on costs.
- Also, runners will be launched in the private subnets **only if the label `private=true` is present** in the `runs-on:` definition. This way, runners will launch in the public subnets by default, and you can selectively use the private subnet (to get the egress static IP) for specific workflows. This saves on NAT bandwidth costs since most workflows don't need static IP.

## Features

- Allow assigning an environment name to a RunsOn stack (default `production`), which can then be targeted by using the `env` label in the workflow. This allows setting up multiple isolated RunsOn stacks to handle environments such as `staging` etc. with different IAM permissions or configurations. Fixes #120.
- Allow specifying a custom VPC CIDR block when creating the stack. This helps if you plan on establishing VPC peering connections with your RunsOn runners. Note that updating this parameter for existing stacks is not recommended. You should create a new stack instead, and remove the old one. Fixes #114.
- Provide a CloudFormation template to facilitate the establishment of a VPC peering connection between RunsOn's VPC, and a destination VPC.
- Allow setting custom tags on the instances launched by RunsOn (`RunnerCustomTags` CloudFormation parameter). Fixes #119.
