### PR TITLE
[Feature Request] Support configuring how MinutesPerDayAlarm treats missing data

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -25,6 +25,7 @@ Metadata:
           default: "Alert settings [optional]"
         Parameters:
           - AppAlarmDailyMinutes
+          - AppAlarmTreatMissingData
           - CostReportsEnabled
           - AlertTopicSubscriptionHttpsEndpoint
       - Label:
@@ -115,6 +116,16 @@ Parameters:
     Type: Number
     Default: "4000"
     Description: "Trigger an alarm if the cumulative number of minutes consumed during a day is over that number."
+
+  AppAlarmTreatMissingData:
+    Type: String
+    Default: "missing"
+    Description: "How to treat missing alarm data (say, if there are no minutes used over the weekend). Values correspond to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-alarm.html#cfn-cloudwatch-alarms-treatmissingdata."
+    AllowedValues:
+      - "breaching"
+      - "notBreaching"
+      - "ignore"
+      - "missing"
 
   AppCPU:
     Type: Number
@@ -1429,6 +1440,7 @@ Resources:
       EvaluationPeriods: 1
       Threshold: !Ref AppAlarmDailyMinutes
       ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: !Ref AppAlarmTreatMissingData
       AlarmActions:
         - !Ref AlertTopic
       OKActions:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -25,7 +25,6 @@ Metadata:
           default: "Alert settings [optional]"
         Parameters:
           - AppAlarmDailyMinutes
-          - AppAlarmTreatMissingData
           - CostReportsEnabled
           - AlertTopicSubscriptionHttpsEndpoint
       - Label:
@@ -116,16 +115,6 @@ Parameters:
     Type: Number
     Default: "4000"
     Description: "Trigger an alarm if the cumulative number of minutes consumed during a day is over that number."
-
-  AppAlarmTreatMissingData:
-    Type: String
-    Default: "missing"
-    Description: "How to treat missing alarm data (say, if there are no minutes used over the weekend). Values correspond to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-alarm.html#cfn-cloudwatch-alarms-treatmissingdata."
-    AllowedValues:
-      - "breaching"
-      - "notBreaching"
-      - "ignore"
-      - "missing"
 
   AppCPU:
     Type: Number
@@ -1440,7 +1429,7 @@ Resources:
       EvaluationPeriods: 1
       Threshold: !Ref AppAlarmDailyMinutes
       ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: !Ref AppAlarmTreatMissingData
+      TreatMissingData: "notBreaching"
       AlarmActions:
         - !Ref AlertTopic
       OKActions:


### PR DESCRIPTION
Hi!  I didn't see a CONTRIBUTING.md, so my apologies if this surprise PR isn't in line with the project's etiquette.  Recently, we received a RunsOn alert email saying the `MinutesPerDayAlarm` had transitioned from `INSUFFICIENT_DATA` to `OK`.  My suspicion is that it occurred because we weren't using our CI over the weekend, which was three days long due to a US holiday.  In case it's helpful, here's a screenshot of our alarm's status over the past month:
<img width="1259" alt="Screenshot 2024-11-12 at 11 18 16" src="https://github.com/user-attachments/assets/1266d4f3-1145-41c6-801b-5c42e4419e06">

This PR is only the first solution I could think of.  I was thinking if we could configure the alarm to ignore missing data, we wouldn't have to worry about false alarms like the one we received today.  But, it'd be even nicer if there was a way to make the alarm report "0 minutes" when there's no usage for a given day, instead of reporting no data at all.  That way, we could still be alerted if the alarm was missing data due to an actual bug.

Thanks for all the work you're doing with RunsOn!