### PR TITLE
add option to omit inbound ssh ingress rule

### DIFF
--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -17,6 +17,7 @@ Metadata:
           - Private
           - NatGatewayElasticIPCount
           - NatGatewayAvailability
+          - AllowInboundSSH
           - SSHCidrRange
           - EC2InstanceCustomPolicy
           - ServerPassword
@@ -77,6 +78,14 @@ Parameters:
     Type: String
     Description: CIDR block for the VPC. Updating this value after creation will require deleting the stack and recreating it.
     Default: 10.1.0.0/16
+
+  AllowInboundSSH:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Allow inbound SSH access to runners?
 
   SSHCidrRange:
     Type: String
@@ -221,6 +230,7 @@ Conditions:
   HasPrivateSubnet: !Not [!Equals [!Ref Private, "false"]]
   PrivateSubnetIsMultiAZ: !And [!Condition HasPrivateSubnet, !Equals [!Ref NatGatewayAvailability, "MultiAZ"]]
   HasEncryptEbs: !Equals [!Ref EncryptEbs, "true"]
+  AllowInboundSSH: !Equals [!Ref AllowInboundSSH, "true"]
   IsPrivateOnly: !Equals [!Ref Private, "only"]
   CustomPolicyProvided: !Not [!Equals [!Ref EC2InstanceCustomPolicy, ""]]
   ECInstanceDetailedMonitoringEnabled: !Equals ["true", !Ref ECInstanceDetailedMonitoring]
@@ -1233,11 +1243,14 @@ Resources:
       VpcId:
         Ref: VPC
       SecurityGroupIngress:
-        - CidrIp:
-            Fn::Sub: "${SSHCidrRange}"
-          FromPort: 22
-          ToPort: 22
-          IpProtocol: tcp
+        - !If
+          - AllowInboundSSH
+          - CidrIp:
+              Fn::Sub: "${SSHCidrRange}"
+            FromPort: 22
+            ToPort: 22
+            IpProtocol: tcp
+          - !Ref "AWS::NoValue"
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName


### PR DESCRIPTION
This resolves #159.

Omitting the rule that allows inbound SSH seems like the simplest approach here, even though it leaves an empty security group in place with a description of "Security group for SSH access". Given that Security Groups have no costs associated with them, that seems like a very minor thing compared to the complexity of **conditionally** removing all references to that group (which would probably make it harder to test as well).

I'm not aware of any documented naming convention, so I opted for naming the Parameter and the Condition the same thing, since it felt more intuitive that way, but I recognize that it's inconsistent with similar cases elsewhere, such as Parameter `EncryptEbs` and Condition `HasEncryptEbs`. If you'd prefer, I could rename the Parameter to `SSHIngressAllowed`, which is more consistent with the other parameter names.

If there's any other changes you'd like, or if this feature is not desirable, please let me know.

Thanks!