### PR TITLE
Add policy to allow server access logs to publish into s3 server access logging bucket

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1583,6 +1583,21 @@ Resources:
             Condition:
               Bool:
                 aws:SecureTransport: false
+          - Sid: S3ServerAccessLogsPolicy
+            Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action: "s3:PutObject"
+            Resource:
+              - !Sub "arn:aws:s3:::${S3BucketLogging}/s3-cache-access-logs/*"
+              - !Sub "arn:aws:s3:::${S3BucketLogging}/s3-config-access-logs/*"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+              ArnLike:
+                aws:Sourcearn:
+                  - !Sub "arn:aws:s3:::${S3BucketCache}"
+                  - !Sub "arn:aws:s3:::${S3Bucket}/*"
 
   EC2InstanceLogGroup:
     Type: AWS::Logs::LogGroup

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1597,7 +1597,7 @@ Resources:
               ArnLike:
                 aws:Sourcearn:
                   - !Sub "arn:aws:s3:::${S3BucketCache}"
-                  - !Sub "arn:aws:s3:::${S3Bucket}/*"
+                  - !Sub "arn:aws:s3:::${S3Bucket}"
 
   EC2InstanceLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Without this, the s3 bucket logging does not work. Tested this by adding the policy via this cloudformation template and observing logs. https://github.com/runs-on/runs-on/issues/241