### PR TITLE
Fix AWS Control Tower hook failure for EC2 launch template public IP

### DIFF
--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -1325,6 +1325,7 @@ Resources:
         NetworkInterfaces:
           - DeleteOnTermination: true
             DeviceIndex: "0"
+            AssociatePublicIpAddress: !If [IsPrivateOnly, false, true]
             Groups:
               - !If [ExternalVpc, !Ref ExternalVpcSecurityGroupId, !Ref SecurityGroup]
             Ipv6AddressCount: !If [HasIpv6Enabled, 1, 0]
@@ -1386,6 +1387,7 @@ Resources:
         NetworkInterfaces:
           - DeleteOnTermination: true
             DeviceIndex: "0"
+            AssociatePublicIpAddress: !If [IsPrivateOnly, false, true]
             Groups:
               - !If [ExternalVpc, !Ref ExternalVpcSecurityGroupId, !Ref SecurityGroup]
             Ipv6AddressCount: !If [HasIpv6Enabled, 1, 0]
@@ -1448,6 +1450,7 @@ Resources:
         NetworkInterfaces:
           - DeleteOnTermination: true
             DeviceIndex: "0"
+            AssociatePublicIpAddress: !If [IsPrivateOnly, false, true]
             Groups:
               - !If [ExternalVpc, !Ref ExternalVpcSecurityGroupId, !Ref SecurityGroup]
             Ipv6AddressCount: !If [HasIpv6Enabled, 1, 0]
@@ -1525,6 +1528,7 @@ Resources:
         NetworkInterfaces:
           - DeleteOnTermination: true
             DeviceIndex: "0"
+            AssociatePublicIpAddress: !If [IsPrivateOnly, false, true]
             Groups:
               - !If [ExternalVpc, !Ref ExternalVpcSecurityGroupId, !Ref SecurityGroup]
             Ipv6AddressCount: !If [HasIpv6Enabled, 1, 0]


### PR DESCRIPTION
Fixes:
The following hook(s) failed: [AWS::ControlTower::Hook] : Hook failed with message: ValidationError [CT.EC2.PR.9]: Require any Amazon EC2 launch template not to auto-assign public IP addresses to network interfaces [FIX]: Set 'AssociatePublicIpAddress' to 'false' within each 'NetworkInterfaces' configuration in 'LaunchTemplateData'.