### PR TITLE
Add AWS Account ID to CloudFormation output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "go.testEnvVars": {
     "AWS_REGION": "us-east-1",
     "AWS_PROFILE": "runs-on-dev-local",
-    "RUNS_ON_STACK_NAME": "runs-on-dev",
+    "RUNS_ON_STACK_NAME": "runs-on-dev"
   },
   "go.testFlags": [
     "-v",

--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -2619,6 +2619,9 @@ Resources:
       Endpoint: !Ref AlertTopicSubscriptionHttpsEndpoint
 
 Outputs:
+  RunsOnAwsAccountId:
+    Description: AWS Account ID
+    Value: !Ref AWS::AccountId
   RunsOnEntryPoint:
     Description: Entrypoint for the RunsOn service
     Value: !GetAtt RunsOnService.ServiceUrl

--- a/cloudformation/template-v2.8.4.yaml
+++ b/cloudformation/template-v2.8.4.yaml
@@ -2619,6 +2619,9 @@ Resources:
       Endpoint: !Ref AlertTopicSubscriptionHttpsEndpoint
 
 Outputs:
+  RunsOnAwsAccountId:
+    Description: AWS Account ID
+    Value: !Ref AWS::AccountId
   RunsOnEntryPoint:
     Description: Entrypoint for the RunsOn service
     Value: !GetAtt RunsOnService.ServiceUrl


### PR DESCRIPTION
In this PR, AWS Account ID has been added to CloudFormation output to be injected in emails.