### PR TITLE
feat: Add ECR Full Access managed policy to obtain higher ECR Public Rate Limits

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1911,7 +1911,10 @@ Resources:
     Properties:
       PermissionsBoundary: !If [HasDefaultPermissionBoundaryArn, !Ref DefaultPermissionBoundaryArn, !Ref "AWS::NoValue"]
       ManagedPolicyArns:
-        !If [CustomPolicyProvided, [!Ref EC2InstanceCustomPolicy, "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]]
+        !If 
+          - CustomPolicyProvided
+          - [!Ref EC2InstanceCustomPolicy, "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicFullAccess"]
+          - ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicFullAccess"]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
We noticed that we intermittently hit ECR public rate limits in some of our actions.  Adding this policy to the EC2 Instance role should authenticate requests to ECR public which provides much more generous [ECR Public rate limits](https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html).

I have not tested this change, and this is my first time writing CloudFormation, so please forgive any non-idomatic stuff I did up there :)
