### PR TITLE
slack format improvements

### DIFF
--- a/cloudformation/template-dev.yaml
+++ b/cloudformation/template-dev.yaml
@@ -2982,7 +2982,7 @@ Resources:
     Condition: CreateDashboard
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://runs-on.s3.eu-west-1.amazonaws.com/cloudformation/dashboard/template-v2.9.1.yaml"
+      TemplateURL: "https://runs-on.s3.eu-west-1.amazonaws.com/cloudformation/dashboard/template-dev.yaml"
       Parameters:
         LogGroupName: !Join
           - ""


### PR DESCRIPTION
a few slight updates to the slack message format

not expecting to merge this exact PR, tracking the code to be included in a further update

adds the runs-on bot icon
uses stack name as the bot name
long messages are expandable with "show more" option for readability
colored sidebars for event type

<img width="1456" height="672" alt="CleanShot 2025-10-18 at 21 37 26@2x" src="https://github.com/user-attachments/assets/3b96c065-6084-47e3-86ad-9e98f560fca7" />
