### PR TITLE
Quiet AWS Control Tower false positive by explictly setting the SqsManagedSseEnabled flag

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -59,6 +59,7 @@ Metadata:
           - ECInstanceDetailedMonitoring
           - Ec2LogRetentionInDays
           - SqsQueueOldestMessageThresholdSeconds
+          - SqsKmsKeyId
       - Label:
           default: "Integrations [optional]"
         Parameters:
@@ -422,6 +423,11 @@ Parameters:
     Default: 0
     Description: Trigger an alarm per sqs queue if the oldest message in that queue is older than this time in seconds. Leave as 0 to disable SQS alarms.
 
+  SqsKmsKeyId:
+    Type: String
+    Default: ""
+    Description: "Optional KMS key ID or ARN for SQS queue encryption. If blank, uses SQS-managed encryption (SSE-SQS). If provided, uses customer-managed KMS key (SSE-KMS) for enhanced control and audit trails."
+
   EnableDashboard:
     Type: String
     Default: "false"
@@ -522,6 +528,7 @@ Conditions:
   CreateEfs: !And [!Condition EmbeddedVpc, !Equals [!Ref EnableEfs, "true"]] # EFS only supported for Embedded VPC for now
   CreateEphemeralRegistry: !Equals [!Ref EnableEphemeralRegistry, "true"]
   CreateDashboard: !Equals [!Ref EnableDashboard, "true"]
+  HasSqsKmsKey: !Not [!Equals [!Ref SqsKmsKeyId, ""]]
 
 Resources:
   VPC:
@@ -2748,6 +2755,8 @@ Resources:
     Properties:
       FifoQueue: true
       MessageRetentionPeriod: 259200 # 3 days
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
 
   RunsOnQueueDeadLetterPolicy:
     Type: AWS::SQS::QueuePolicy
@@ -2773,6 +2782,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 10
       VisibilityTimeout: 120 # AWS recommends 6 times the max processing time
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RunsOnQueueDeadLetter.Arn
         maxReceiveCount: 5
@@ -2787,6 +2798,8 @@ Resources:
     Properties:
       MessageRetentionPeriod: 259200 # 3 days
       FifoQueue: true
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName
@@ -2801,6 +2814,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 10
       VisibilityTimeout: 120 # 2 minutes for scheduling
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RunsOnQueueJobsDeadLetter.Arn
         maxReceiveCount: 3
@@ -2815,6 +2830,8 @@ Resources:
     Properties:
       MessageRetentionPeriod: 259200 # 3 days
       FifoQueue: true
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName
@@ -2829,6 +2846,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 10
       VisibilityTimeout: 120 # GitHub API calls + S3 uploads
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RunsOnQueueGithubDeadLetter.Arn
         maxReceiveCount: 3
@@ -2842,6 +2861,8 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 259200 # 3 days
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName
@@ -2854,6 +2875,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 10
       VisibilityTimeout: 120
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RunsOnQueuePoolDeadLetter.Arn
         maxReceiveCount: 5
@@ -2869,6 +2892,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 20
       VisibilityTimeout: 120
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName
@@ -2881,6 +2906,8 @@ Resources:
       MessageRetentionPeriod: 86400 # 24h
       ReceiveMessageWaitTimeSeconds: 20
       VisibilityTimeout: 120
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName
@@ -2893,6 +2920,8 @@ Resources:
       MessageRetentionPeriod: 7200
       ReceiveMessageWaitTimeSeconds: 20
       VisibilityTimeout: 120
+      KmsMasterKeyId: !If [HasSqsKmsKey, !Ref SqsKmsKeyId, !Ref "AWS::NoValue"]
+      SqsManagedSseEnabled: !If [HasSqsKmsKey, !Ref "AWS::NoValue", true]
       Tags:
         - Key: !Ref CostAllocationTag
           Value: !Ref AWS::StackName


### PR DESCRIPTION
## Summary

Fixes #444 

Adds encryption at rest to all SQS queues to satisfy AWS Control Tower security control CT.SQS.PR.2, with optional support for customer-managed KMS keys.

## Problem

When deploying the CloudFormation stack in AWS accounts with Control Tower enabled, the deployment fails with:

```
AWS::ControlTower::Hook Hook failed with message: ValidationError [CT.SQS.PR.2]: 
Require any Amazon SQS queue to have encryption at rest configured [FIX]: 
Set 'SqsManagedSseEnabled' to 'true' or set an AWS KMS key identifier in the 'KmsMasterKeyId' property.
```

## Changes

### New Parameter

Added `SqsKmsKeyId` (optional) parameter:
- **Default**: Empty (uses SQS-managed encryption)
- **Purpose**: Allows organizations to provide their own KMS key ID or ARN for enhanced control

### Queue Updates

All 11 SQS queues now support encryption at rest with conditional logic:

- When `SqsKmsKeyId` is **empty** (default):
  - Uses `SqsManagedSseEnabled: true` (SSE-SQS)
  - AWS-managed encryption keys
  - No additional cost
  - No additional permissions required
  
- When `SqsKmsKeyId` is **provided**:
  - Uses `KmsMasterKeyId: <your-key>` (SSE-KMS)
  - Customer-managed KMS key
  - Enhanced control and audit trails
  - Custom key policies and rotation

**Affected queues:**
- RunsOnQueueDeadLetter
- RunsOnQueue
- RunsOnQueueJobsDeadLetter
- RunsOnQueueJobs
- RunsOnQueueGithubDeadLetter
- RunsOnQueueGithub
- RunsOnQueuePoolDeadLetter
- RunsOnQueuePool
- RunsOnQueueHousekeeping
- RunsOnQueueTermination
- RunsOnQueueEvents

## Solution Details

### Default: SSE-SQS (SQS-Managed Encryption)

The default configuration uses **SQS-managed server-side encryption**, which:
- ✅ Provides encryption at rest using AWS-managed keys
- ✅ Has **no additional cost**
- ✅ Requires **no additional AWS resources** (no KMS key needed)
- ✅ Requires **no additional IAM permissions**
- ✅ Is the simplest solution for Control Tower compliance
- ✅ Is transparent to applications (no code changes needed)
- ✅ Works in all scenarios (cross-account, etc.)

### Optional: SSE-KMS (Customer-Managed Encryption)

Organizations with stricter compliance requirements can provide their own KMS key:
- Enhanced audit trails via CloudTrail
- Custom key policies and access controls
- Ability to disable/rotate keys
- Cross-region replication support
- Required for some compliance frameworks (PCI-DSS, HIPAA, etc.)

**Note**: Using `alias/aws/sqs` (AWS-managed KMS key) as a default was considered but rejected because:
- Requires additional KMS IAM permissions
- Has KMS request costs (minimal but non-zero)
- Cannot be used in cross-account scenarios
- Could break existing deployments
- SSE-SQS is simpler and sufficient for most use cases

## Testing

- ✅ All queues include conditional encryption properties
- ✅ CloudFormation template syntax is valid
- ✅ No breaking changes - existing deployments continue working
- ✅ Backward compatible - encryption enabled by default with SSE-SQS
- ✅ Forward compatible - users can migrate to KMS when needed

## Impact

This change enables deployment in AWS accounts with:
- AWS Control Tower enabled
- Security controls/SCPs requiring encryption at rest
- Compliance requirements mandating encryption

**Backward Compatibility**: ✅ Existing stacks will automatically use SSE-SQS encryption on next update. No configuration changes required.

## References

- [AWS Control Tower Hook CT.SQS.PR.2](https://docs.aws.amazon.com/controltower/latest/userguide/elective-controls.html#ct-sqs-pr-2)
- [AWS SQS Encryption at Rest](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html)
- [CloudFormation AWS::SQS::Queue Properties](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html)
- [SQS SSE-SQS vs SSE-KMS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sse-existing-queue.html)