### PR TITLE
dashboard: track min ready instances to surface pool availability dips

### DIFF
--- a/cloudformation/dashboard/template-dev.yaml
+++ b/cloudformation/dashboard/template-dev.yaml
@@ -239,7 +239,7 @@ Resources:
               "width": 12,
               "height": 6,
               "properties": {
-                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"hot\":(?<hot>\\d+)/\n| parse pool_data /\"stopped\":(?<stopped>\\d+)/\n| parse pool_data /\"warming\":(?<warming>\\d+)/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| parse pool_data /\"ready_to_stop\":(?<ready_to_stop>\\d+)/\n| parse pool_data /\"detached\":(?<detached>\\d+)/\n| parse pool_data /\"error\":(?<error>\\d+)/\n| parse pool_data /\"outdated\":(?<outdated>\\d+)/\n| parse pool_data /\"dangling\":(?<dangling>\\d+)/\n| stats max(hot) as max_hot, max(stopped) as max_stopped, max(warming) as max_warming, max(ready) as max_ready, max(ready_to_stop) as max_ready_to_stop, max(detached) as max_detached, max(error) as max_error, max(outdated) as max_outdated, max(dangling) as max_dangling by bin(5m) as t, pool_name\n| sort t desc, pool_name asc",
+                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"hot\":(?<hot>\\d+)/\n| parse pool_data /\"stopped\":(?<stopped>\\d+)/\n| parse pool_data /\"warming\":(?<warming>\\d+)/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| parse pool_data /\"ready_to_stop\":(?<ready_to_stop>\\d+)/\n| parse pool_data /\"detached\":(?<detached>\\d+)/\n| parse pool_data /\"error\":(?<error>\\d+)/\n| parse pool_data /\"outdated\":(?<outdated>\\d+)/\n| parse pool_data /\"dangling\":(?<dangling>\\d+)/\n| stats min(ready) as min_ready, max(hot) as max_hot, max(stopped) as max_stopped, max(warming) as max_warming, max(ready) as max_ready, max(ready_to_stop) as max_ready_to_stop, max(detached) as max_detached, max(error) as max_error, max(outdated) as max_outdated, max(dangling) as max_dangling by bin(5m) as t, pool_name\n| sort t desc, pool_name asc",
                 "region": "${AWS::Region}",
                 "title": "Pool Instances Over Time",
                 "view": "table"
@@ -269,6 +269,25 @@ Resources:
                 "region": "${AWS::Region}",
                 "title": "Recent Spot Interruptions (Last 50)",
                 "view": "table"
+              }
+            },
+            {
+              "type": "log",
+              "x": 0,
+              "y": 30,
+              "width": 24,
+              "height": 6,
+              "properties": {
+                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| stats min(ready) as min_ready by bin(5m) as t, pool_name\n| sort t asc",
+                "region": "${AWS::Region}",
+                "title": "Pool Min Ready Instances Over Time",
+                "view": "timeSeries",
+                "yAxis": {
+                  "left": {
+                    "min": 0,
+                    "label": "Instances"
+                  }
+                }
               }
             }
           ]

--- a/cloudformation/dashboard/template.yaml
+++ b/cloudformation/dashboard/template.yaml
@@ -239,7 +239,7 @@ Resources:
               "width": 12,
               "height": 6,
               "properties": {
-                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"hot\":(?<hot>\\d+)/\n| parse pool_data /\"stopped\":(?<stopped>\\d+)/\n| parse pool_data /\"warming\":(?<warming>\\d+)/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| parse pool_data /\"ready_to_stop\":(?<ready_to_stop>\\d+)/\n| parse pool_data /\"detached\":(?<detached>\\d+)/\n| parse pool_data /\"error\":(?<error>\\d+)/\n| parse pool_data /\"outdated\":(?<outdated>\\d+)/\n| parse pool_data /\"dangling\":(?<dangling>\\d+)/\n| stats max(hot) as max_hot, max(stopped) as max_stopped, max(warming) as max_warming, max(ready) as max_ready, max(ready_to_stop) as max_ready_to_stop, max(detached) as max_detached, max(error) as max_error, max(outdated) as max_outdated, max(dangling) as max_dangling by bin(5m) as t, pool_name\n| sort t desc, pool_name asc",
+                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"hot\":(?<hot>\\d+)/\n| parse pool_data /\"stopped\":(?<stopped>\\d+)/\n| parse pool_data /\"warming\":(?<warming>\\d+)/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| parse pool_data /\"ready_to_stop\":(?<ready_to_stop>\\d+)/\n| parse pool_data /\"detached\":(?<detached>\\d+)/\n| parse pool_data /\"error\":(?<error>\\d+)/\n| parse pool_data /\"outdated\":(?<outdated>\\d+)/\n| parse pool_data /\"dangling\":(?<dangling>\\d+)/\n| stats min(ready) as min_ready, max(hot) as max_hot, max(stopped) as max_stopped, max(warming) as max_warming, max(ready) as max_ready, max(ready_to_stop) as max_ready_to_stop, max(detached) as max_detached, max(error) as max_error, max(outdated) as max_outdated, max(dangling) as max_dangling by bin(5m) as t, pool_name\n| sort t desc, pool_name asc",
                 "region": "${AWS::Region}",
                 "title": "Pool Instances Over Time",
                 "view": "table"
@@ -269,6 +269,25 @@ Resources:
                 "region": "${AWS::Region}",
                 "title": "Recent Spot Interruptions (Last 50)",
                 "view": "table"
+              }
+            },
+            {
+              "type": "log",
+              "x": 0,
+              "y": 30,
+              "width": 24,
+              "height": 6,
+              "properties": {
+                "query": "SOURCE '${LogGroupName}'\n| filter metric_type = \"snapshot\" and ispresent(pools.0.dangling)\n| parse @message /\\[(?<pool_data>.*)\\]/\n| parse pool_data /\"pool_name\":\"(?<pool_name>[^\"]+)\"/\n| parse pool_data /\"ready\":(?<ready>\\d+)/\n| stats min(ready) as min_ready by bin(5m) as t, pool_name\n| sort t asc",
+                "region": "${AWS::Region}",
+                "title": "Pool Min Ready Instances Over Time",
+                "view": "timeSeries",
+                "yAxis": {
+                  "left": {
+                    "min": 0,
+                    "label": "Instances"
+                  }
+                }
               }
             }
           ]


### PR DESCRIPTION
## Summary

- Adds `min_ready` column to the **Pool Instances Over Time** table so you can spot windows where a pool briefly had fewer ready runners than expected (max alone would hide these dips)
- Adds a new full-width **Pool Min Ready Instances Over Time** time series chart, giving a visual trend of runner availability per pool over time

## Motivation

`max(ready)` tells you the best-case snapshot in a 5-minute bin, but a pool could have hit zero ready instances within that window and you'd never know. Tracking `min(ready)` surfaces those shortfalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)